### PR TITLE
Enable eslint rules and fix warnings and errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,29 +22,9 @@ module.exports = {
 
         // following rules are disabled temporary in order to fix project build
         // todo: enable rules below and fix errors
-        '@typescript-eslint/camelcase': 'off',
-        '@typescript-eslint/class-name-casing': 'off',
-        '@typescript-eslint/consistent-type-assertions': 'off',
-        '@typescript-eslint/explicit-function-return-type': 'off',
-        '@typescript-eslint/interface-name-prefix': 'off',
-        '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off',
-        '@typescript-eslint/no-this-alias': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
-        '@typescript-eslint/no-use-before-define': 'off',
-        '@typescript-eslint/no-var-requires': 'off',
-        'no-var': 'off',
-        'prefer-const': 'off',
-        'prefer-rest-params': 'off',
-        'prefer-spread': 'off',
-        'react/display-name': 'off',
         'react/jsx-key': 'off',
-        'react/jsx-no-target-blank': 'off',
         'react/no-children-prop': 'off',
-        'react/no-find-dom-node': 'off',
-        'react/no-unescaped-entities': 'off',
-        'react/prop-types': 'off',
     },
     settings: {
         react: {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "compile:source-map": "yarn run compile --devtool source-map",
     "start": "webpack-dev-server --progress --color --config webpack.config.dev.js",
     "format": "tsfmt -r --useTsfmt tsfmt.json",
-    "lint": "tsc --noEmit && eslint 'src/**/*.{js,ts,tsx}' --fix",
+    "lint:fix": "tsc --noEmit && eslint '*/**/*.{js,ts,tsx}' --fix",
     "serve:prod": "yarn run compile:source-map && webpack-dev-server --color --disable-host-check --config webpack.config.prod-dev.js"
   },
   "husky": {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -11,7 +11,6 @@ import IdeIframe from './ide-iframe/IdeIframe';
 
 import './app.styl';
 
-
 type Item = {
   to: string;
   component: React.FunctionComponent<any>;
@@ -28,7 +27,7 @@ const items: Item[] = [
   { to: '/ide/:namespace/:workspaceName/', component: IdeIframe },
 ];
 
-export default (props: { history: any }) => {
+const LayoutComponent = (props: { history: any }): React.ReactElement => {
   return (<Router history={props.history}>
     <Layout items={items.map(item => ({ to: item.to, label: item.label, ico: item.ico }))}>
       {items.map((item: Item, index: number) => (
@@ -38,3 +37,7 @@ export default (props: { history: any }) => {
     </Layout>
   </Router>);
 };
+
+LayoutComponent.displayName = 'LayoutComponent';
+
+export default LayoutComponent;

--- a/src/components/app-common/devfile-editor/DevfileEditor.tsx
+++ b/src/components/app-common/devfile-editor/DevfileEditor.tsx
@@ -152,7 +152,7 @@ class DevfileEditor extends React.PureComponent<Props, { errorMessage: string }>
       <div className='devfile-editor'>
         <div className='monaco'>&nbsp;</div>
         <div className='error'>{errorMessage}</div>
-        <a target='_blank' rel="noopener noreferrer" href={href}>Docs: Devfile Structure</a>
+        <a target='_blank' rel='noopener noreferrer' href={href}>Docs: Devfile Structure</a>
       </div>
     );
   }

--- a/src/components/app-common/devfile-editor/DevfileEditor.tsx
+++ b/src/components/app-common/devfile-editor/DevfileEditor.tsx
@@ -14,7 +14,7 @@ import * as $ from 'jquery';
 
 import './devfile-editor.styl';
 
-interface IEditor {
+interface Editor {
   getValue(): string;
   getModel(): any;
 }
@@ -26,9 +26,9 @@ const MONACO_CONFIG = { language: 'yaml', wordWrap: 'on', lineNumbers: 'on', mat
 
 type Props = { devfilesRegistry: DevfilesRegistry.DevfilesState; branding: { branding: BrandingState } } // Redux store
   & {
-    devfile: che.IWorkspaceDevfile;
+    devfile: che.WorkspaceDevfile;
     decorationPattern?: string;
-    onChange?: (devfile: che.IWorkspaceDevfile, isValid: boolean) => void;
+    onChange?: (devfile: che.WorkspaceDevfile, isValid: boolean) => void;
     setUpdateEditorCallback?: (Function) => void;
   };
 
@@ -38,7 +38,7 @@ class DevfileEditor extends React.PureComponent<Props, { errorMessage: string }>
   private yamlService: any;
   private m2p = new monacoConversion.MonacoToProtocolConverter();
   private p2m = new monacoConversion.ProtocolToMonacoConverter();
-  private createDocument = model => yamlLanguageServer.TextDocument.create(
+  private createDocument = (model): yamlLanguageServer.TextDocument => yamlLanguageServer.TextDocument.create(
     'inmemory://model.yaml',
     model.getModeId(),
     model.getVersionId(),
@@ -94,7 +94,7 @@ class DevfileEditor extends React.PureComponent<Props, { errorMessage: string }>
   }
 
   // This method is called when the component is first added to the document
-  public componentDidMount() {
+  public componentDidMount(): void {
     const element = $('.devfile-editor .monaco').get(0);
     if (element) {
       const value = dump(this.props.devfile, { 'indent': 1 });
@@ -106,7 +106,7 @@ class DevfileEditor extends React.PureComponent<Props, { errorMessage: string }>
       const doc = this.editor.getModel();
       doc.updateOptions({ tabSize: 2 });
 
-      const handleResize = () => {
+      const handleResize = (): void => {
         const layout = { height: element.offsetHeight, width: element.offsetWidth };
         this.editor.layout(layout);
       };
@@ -124,7 +124,7 @@ class DevfileEditor extends React.PureComponent<Props, { errorMessage: string }>
       });
 
       let oldDecorationIds: string[] = []; // Array containing previous decorations identifiers.
-      const updateDecorations = () => {
+      const updateDecorations = (): void => {
         if (this.props.decorationPattern) {
           oldDecorationIds = this.editor.deltaDecorations(oldDecorationIds, this.getDecorations());
         }
@@ -140,11 +140,11 @@ class DevfileEditor extends React.PureComponent<Props, { errorMessage: string }>
   }
 
   // This method is called when the component is removed from the document
-  public componentWillUnmount() {
+  public componentWillUnmount(): void {
     this.toDispose.dispose();
   }
 
-  public render() {
+  public render(): React.ReactElement {
     const href = (this.props.branding.branding.branding.docs as any).devfile;
     const { errorMessage } = this.state;
 
@@ -152,7 +152,7 @@ class DevfileEditor extends React.PureComponent<Props, { errorMessage: string }>
       <div className='devfile-editor'>
         <div className='monaco'>&nbsp;</div>
         <div className='error'>{errorMessage}</div>
-        <a target='_blank' href={href}>Docs: Devfile Structure</a>
+        <a target='_blank' rel="noopener noreferrer" href={href}>Docs: Devfile Structure</a>
       </div>
     );
   }
@@ -185,7 +185,7 @@ class DevfileEditor extends React.PureComponent<Props, { errorMessage: string }>
   }
 
   private onChange(newValue: string, isValid: boolean): void {
-    let devfile: che.IWorkspaceDevfile;
+    let devfile: che.WorkspaceDevfile;
     try {
       devfile = load(newValue);
     } catch (e) {
@@ -227,7 +227,7 @@ class DevfileEditor extends React.PureComponent<Props, { errorMessage: string }>
     });
   }
 
-  private initLanguageServerValidation(editor: IEditor): void {
+  private initLanguageServerValidation(editor: Editor): void {
     const model = editor.getModel();
     let validationTimer: any;
 

--- a/src/components/app-common/devfile-editor/monaco-theme-register.ts
+++ b/src/components/app-common/devfile-editor/monaco-theme-register.ts
@@ -2,7 +2,7 @@ import * as Monaco from 'monaco-editor-core/esm/vs/editor/editor.main';
 
 export const DEFAULT_CHE_THEME = 'che';
 
-export const registerCustomThemes = () => {
+export const registerCustomThemes = (): void => {
 
   // register the white editor theme
   Monaco.editor.defineTheme(DEFAULT_CHE_THEME, {

--- a/src/components/app-common/loaders/Loader.tsx
+++ b/src/components/app-common/loaders/Loader.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 
-const Loader = () => {
+const Loader = (): React.ReactElement => {
   const branding = useSelector((state: { branding: { loaderURL: string } }) => state.branding);
 
   return <div className='main-page-loader'>

--- a/src/components/app-common/progress/progress.tsx
+++ b/src/components/app-common/progress/progress.tsx
@@ -16,13 +16,13 @@ class CheProgress extends React.PureComponent<{ isLoading: boolean }, { progress
 
     this.state = { progressVal: 0 };
 
-    this.onProgressInc = () => {
+    this.onProgressInc = (): void => {
       const progressVal = this.state.progressVal < 100 ? this.state.progressVal + 5 : 0;
       this.setState({ progressVal });
     };
   }
 
-  private updateProgressInterval() {
+  private updateProgressInterval(): void {
     if (this.props.isLoading) {
       if (!this.intervalId) {
         this.intervalId = setInterval(() => {
@@ -40,23 +40,23 @@ class CheProgress extends React.PureComponent<{ isLoading: boolean }, { progress
   }
 
   // This method is called when the component is first added to the document
-  public componentDidMount() {
+  public componentDidMount(): void {
     this.updateProgressInterval();
   }
 
   // This method is called when the route parameters change
-  public componentDidUpdate() {
+  public componentDidUpdate(): void {
     this.updateProgressInterval();
   }
 
   // This method is called when the component is removed from the document
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     if (this.intervalId) {
       clearInterval(this.intervalId);
     }
   }
 
-  public render() {
+  public render(): React.ReactElement {
     const { progressVal } = this.state;
 
     return (

--- a/src/components/app-nav-menu/Layout.tsx
+++ b/src/components/app-nav-menu/Layout.tsx
@@ -4,7 +4,7 @@ import { AppState } from '../../store';
 import { NavMenu } from './NavMenu';
 import Loader from '../app-common/loaders/Loader';
 
-export default (props: { items: { to: string; label?: string }[]; children?: React.ReactNode }) => {
+const NavMenuComponent = (props: { items: { to: string; label?: string }[]; children?: React.ReactNode }): React.ReactElement => {
   const state = useSelector((state: AppState) => state);
   if (!state.user.isLogged) {
     return <Loader />;
@@ -20,3 +20,7 @@ export default (props: { items: { to: string; label?: string }[]; children?: Rea
         children={props.children} />
     </React.Fragment>);
 };
+
+NavMenuComponent.displayName = 'NavMenuComponent';
+
+export default NavMenuComponent;

--- a/src/components/app-nav-menu/NavMenu.tsx
+++ b/src/components/app-nav-menu/NavMenu.tsx
@@ -53,27 +53,27 @@ export class NavMenu extends React.PureComponent<any, any> {
 
     const keycloak = container.get(Keycloak);
 
-    this.onTheme = (theme: string) => {
+    this.onTheme = (theme: string): void => {
       this.setState({ theme });
       window.sessionStorage.setItem('theme', theme);
     };
-    this.onLogout = () => {
+    this.onLogout = (): void => {
       keycloak.logout();
     };
-    this.onDropdownToggle = (isDropdownOpen: any) => {
+    this.onDropdownToggle = (isDropdownOpen: any): void => {
       this.setState({ isDropdownOpen })
     };
-    this.onDropdownSelect = () => {
+    this.onDropdownSelect = (): void => {
       this.setState({ isDropdownOpen: !this.state.isDropdownOpen });
     };
-    this.onNavSelect = (result: any) => {
+    this.onNavSelect = (result: any): void => {
       this.setState({ activeItem: result.itemId });
     };
-    this.onNavToggle = () => {
+    this.onNavToggle = (): void => {
       this.setState({ isNavOpen: !this.state.isNavOpen });
     };
 
-    this.handleMessage = event => {
+    this.handleMessage = (event): void => {
       if (event.data === 'show-navbar') {
         this.setState({ isNavOpen: true });
       } else if (event.data === 'hide-navbar') {
@@ -82,15 +82,15 @@ export class NavMenu extends React.PureComponent<any, any> {
     }
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     window.addEventListener('message', this.handleMessage, false);
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     window.removeEventListener('message', this.handleMessage);
   }
 
-  render() {
+  render(): React.ReactElement {
     const { isDropdownOpen, activeItem, isNavOpen, theme } = this.state;
     // create a Sidebar
     const PageNav = (
@@ -121,7 +121,7 @@ export class NavMenu extends React.PureComponent<any, any> {
       </Nav>
     );
 
-    const getUserName = () => {
+    const getUserName = (): string => {
       const user = this.props.user;
       if (user.given_name && user.family_name) {
         return `${user.given_name} ${user.family_name}`;
@@ -130,8 +130,8 @@ export class NavMenu extends React.PureComponent<any, any> {
     };
 
     const UserDropdownItems = [
-      <DropdownItem key='white' onClick={() => this.onTheme(LIGHT)} component='button'>Light theme</DropdownItem>,
-      <DropdownItem key='dark' onClick={() => this.onTheme(DARK)} component='button'>Dadark theme</DropdownItem>,
+      <DropdownItem key='white' onClick={(): void => this.onTheme(LIGHT)} component='button'>Light theme</DropdownItem>,
+      <DropdownItem key='dark' onClick={(): void => this.onTheme(DARK)} component='button'>Dadark theme</DropdownItem>,
       <DropdownItem key='account_details'>Account details</DropdownItem>,
       <DropdownItem key='account_logout' onClick={this.onLogout} component='button'>Logout</DropdownItem>
     ];

--- a/src/components/app-nav-menu/administration/Administration.tsx
+++ b/src/components/app-nav-menu/administration/Administration.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Gallery, PageSection, Text, TextContent } from "@patternfly/react-core";
 
-const Administration = () => (
+const Administration = (): React.ReactElement => (
   <React.Fragment>
     <PageSection>
       <TextContent>

--- a/src/components/app-nav-menu/dashboard/Dashboard.tsx
+++ b/src/components/app-nav-menu/dashboard/Dashboard.tsx
@@ -1,17 +1,13 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import {
-  Card,
-  CardBody,
   Gallery,
-  GalleryItem,
   PageSection,
-  PageSectionVariants,
   Text,
   TextContent
 } from "@patternfly/react-core";
 
-const Dashboard = () => (
+const Dashboard = (): React.ReactElement => (
   <React.Fragment>
     <PageSection>
       <TextContent>

--- a/src/components/app-nav-menu/get-started/SamplesList.tsx
+++ b/src/components/app-nav-menu/get-started/SamplesList.tsx
@@ -40,12 +40,12 @@ export class SamplesList extends React.PureComponent<DevfilesRegistryProps, { al
     this.debounce = container.get(Debounce);
 
     this.state = { alertVisible: false };
-    this.showAlert = (variant: 'success' | 'danger', title: string, timeDelay?: number) => {
+    this.showAlert = (variant: 'success' | 'danger', title: string, timeDelay?: number): void => {
       this.alert = { variant, title };
       this.setState({ alertVisible: true });
       this.debounce.setDelay(timeDelay);
     };
-    this.hideAlert = () => this.setState({ alertVisible: false });
+    this.hideAlert = (): void => this.setState({ alertVisible: false });
 
     this.debounce.subscribe(isDebounceDelay => {
       if (!isDebounceDelay) {
@@ -54,17 +54,17 @@ export class SamplesList extends React.PureComponent<DevfilesRegistryProps, { al
     });
   }
 
-  public render() {
+  public render(): React.ReactElement {
     const { alertVisible } = this.state;
     const { data } = this.props.devfilesRegistry;
 
-    const createWorkspace = (registryUrl: string, devfile: che.IDevfileMetaData) => {
+    const createWorkspace = (registryUrl: string, devfile: che.DevfileMetaData): void => {
       if (this.debounce.hasDelay() || !devfile.links || !devfile.links.self) {
         return;
       }
       const devfileUrl = registryUrl + devfile.links.self;
       const attr = { stackName: devfile.displayName };
-      this.props.createWorkspace(devfileUrl, attr).then((workspace: che.IWorkspace) => {
+      this.props.createWorkspace(devfileUrl, attr).then((workspace: che.Workspace) => {
         const workspaceName = workspace.devfile.metadata.name;
         this.showAlert('success', `Workspace ${workspaceName} has been created`, 1500);
         // force start for the new workspace
@@ -101,12 +101,12 @@ export class SamplesList extends React.PureComponent<DevfilesRegistryProps, { al
         <CheProgress isLoading={this.props.workspaces.isLoading} />
         <PageSection>
           <Gallery gutter='md'>
-            {data.map((data: { devfiles: che.IDevfileMetaData[]; registryUrl: string }, index: number) => (
-              data.devfiles.map((devfile: che.IDevfileMetaData, key: number) => (
+            {data.map((data: { devfiles: che.DevfileMetaData[]; registryUrl: string }, index: number) => (
+              data.devfiles.map((devfile: che.DevfileMetaData, key: number) => (
                 <div
                   className='pf-c-card pf-m-hoverable pf-m-compact get-started-template'
                   key={`${index}_${key}`}
-                  onClick={() => createWorkspace(data.registryUrl, devfile)}>
+                  onClick={(): void => createWorkspace(data.registryUrl, devfile)}>
                   <div className='pf-c-card__head'>
                     <img alt='Icon' src={`${data.registryUrl}${devfile.icon}`} />
                   </div>

--- a/src/components/app-nav-menu/workspaces/WorkspacesList.tsx
+++ b/src/components/app-nav-menu/workspaces/WorkspacesList.tsx
@@ -32,34 +32,34 @@ export class WorkspacesList extends React.PureComponent<WorkspacesProps> {
   }
 
   // This method is called when the component is first added to the document
-  public componentDidMount() {
+  public componentDidMount(): void {
     this.ensureDataFetched();
   }
 
   // This method is called when the route parameters change
-  public componentDidUpdate() {
+  public componentDidUpdate(): void {
     this.ensureDataFetched();
   }
 
-  public render() {
-    const onRowClick = (workspace: che.IWorkspace) => {
+  public render(): React.ReactElement {
+    const onRowClick = (workspace: che.Workspace): void => {
       this.props.history.push(`/workspace/${workspace.namespace}/${workspace.devfile.metadata.name}`);
     };
 
     const columns = ['NAME', 'RAM', 'PROJECTS', 'STACK', 'ACTIONS'];
-    const rows = this.props.workspaces.workspaces.map((workspace: che.IWorkspace, key: number) => ({
+    const rows = this.props.workspaces.workspaces.map((workspace: che.Workspace, key: number) => ({
       cells: [
-        <span onClick={() => onRowClick(workspace)}>
+        <span onClick={(): void => onRowClick(workspace)}>
           <WorkspaceIndicator key={`indicator_${key}`} status={workspace.status} />
           {workspace.namespace}/{workspace.devfile.metadata.name}
         </span>,
-        <span onClick={() => onRowClick(workspace)}>
+        <span onClick={(): void => onRowClick(workspace)}>
           -
                     </span>,
-        <span onClick={() => onRowClick(workspace)}>
+        <span onClick={(): void => onRowClick(workspace)}>
           {workspace.devfile.projects ? workspace.devfile.projects.length : '-'}
         </span>,
-        <span onClick={() => onRowClick(workspace)}>
+        <span onClick={(): void => onRowClick(workspace)}>
           {workspace.attributes && workspace.attributes.stackName ? workspace.attributes.stackName : ''}
         </span>,
         <span>
@@ -90,7 +90,7 @@ export class WorkspacesList extends React.PureComponent<WorkspacesProps> {
         </Text>
         <CheProgress isLoading={this.props.workspaces.isLoading} />
         <PageSection variant={SECTION_THEME} className='header-buttons'>
-          <Button onClick={() => this.props.history.push(creationLink)} variant='primary'>
+          <Button onClick={(): void => this.props.history.push(creationLink)} variant='primary'>
             Add Workspace
                     </Button>
         </PageSection>
@@ -109,7 +109,7 @@ export class WorkspacesList extends React.PureComponent<WorkspacesProps> {
     );
   }
 
-  private ensureDataFetched() {
+  private ensureDataFetched(): void {
     if (this.debounce.hasDelay()) {
       return;
     }

--- a/src/components/app-nav-menu/workspaces/actions/DeleteWorkspace.tsx
+++ b/src/components/app-nav-menu/workspaces/actions/DeleteWorkspace.tsx
@@ -23,21 +23,21 @@ class DeleteWorkspace extends React.PureComponent<DeleteWorkspaceProps, { isDebo
   }
 
   // This method is called when the component is removed from the document
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     this.debounce.unsubscribeAll();
   }
 
-  private isDisabled = () => {
+  private isDisabled = (): boolean => {
     return this.debounce.hasDelay() || this.props.status !== STOPPED;
   };
 
-  public render() {
+  public render(): React.ReactElement {
 
     return (
       <span className={this.isDisabled() ?
         'disabled-delete-workspace' :
         'delete-workspace'}
-        onClick={e => {
+        onClick={(e): void => {
           e.stopPropagation();
           this.onActionClick();
         }}>
@@ -48,7 +48,7 @@ class DeleteWorkspace extends React.PureComponent<DeleteWorkspaceProps, { isDebo
     );
   }
 
-  private onActionClick() {
+  private onActionClick(): void {
     if (this.isDisabled()) {
       return;
     }

--- a/src/components/app-nav-menu/workspaces/actions/WorkspaceStatus.tsx
+++ b/src/components/app-nav-menu/workspaces/actions/WorkspaceStatus.tsx
@@ -24,22 +24,22 @@ class WorkspaceStatus extends React.PureComponent<WorkspaceStatusProps, { isDebo
   }
 
   // This method is called when the component is removed from the document
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     this.debounce.unsubscribeAll();
   }
 
-  private isDisabled = () => {
+  private isDisabled = (): boolean => {
     return this.debounce.hasDelay() || (this.props.status !== STOPPED && this.props.status !== RUNNING);
   };
 
-  public render() {
-    const tooltipContent = () => this.props.status === STOPPED ? 'Run Workspace' : 'Stop workspace';
-    const iconClass = () => this.props.status === STOPPED ? 'fa fa-play' : 'fa fa-stop';
+  public render(): React.ReactElement {
+    const tooltipContent = (): string => this.props.status === STOPPED ? 'Run Workspace' : 'Stop workspace';
+    const iconClass = (): string => this.props.status === STOPPED ? 'fa fa-play' : 'fa fa-stop';
 
     return (
       <span key={`wrks-status-${this.props.workspaceId}`}
         className={this.isDisabled() ? 'disabled-workspace-status' : 'workspace-status'}
-        onClick={e => {
+        onClick={(e): void => {
           e.stopPropagation();
           this.onActionClick();
         }}>
@@ -51,7 +51,7 @@ class WorkspaceStatus extends React.PureComponent<WorkspaceStatusProps, { isDebo
     );
   }
 
-  private onActionClick() {
+  private onActionClick(): void {
     if (this.isDisabled()) {
       return;
     }

--- a/src/components/app-nav-menu/workspaces/workspace-indicator/WorkspaceIndicator.tsx
+++ b/src/components/app-nav-menu/workspaces/workspace-indicator/WorkspaceIndicator.tsx
@@ -10,7 +10,7 @@ const STOPPING = 'STOPPING';
 
 class WorkspaceIndicator extends React.PureComponent<{ status: string | undefined }> {
 
-  public render() {
+  public render(): React.ReactElement {
 
     if (this.props.status === STARTING || this.props.status === STOPPING) {
       return (
@@ -24,7 +24,7 @@ class WorkspaceIndicator extends React.PureComponent<{ status: string | undefine
       );
     }
 
-    const iconClass = (status: string | undefined) => {
+    const iconClass = (status: string | undefined): string => {
       if (status === ERROR) {
         return 'fa fa-circle workspace-status-error';
       }

--- a/src/components/ide-iframe/IdeIframe.tsx
+++ b/src/components/ide-iframe/IdeIframe.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 
-const IdeIframe = (props: RouteComponentProps<{ namespace: string; workspaceName: string }>) => {
+const IdeIframe = (props: RouteComponentProps<{ namespace: string; workspaceName: string }>): React.ReactElement => {
   const randVal = Math.floor((Math.random() * 1000000) + 1);
   const { namespace, workspaceName } = props.match.params;
 

--- a/src/components/workspace-details/WorkspaceDetails.tsx
+++ b/src/components/workspace-details/WorkspaceDetails.tsx
@@ -28,7 +28,7 @@ type WorkspaceDetailsProps =
   & { history: any } // ... plus history
   & RouteComponentProps<{ namespace: string; workspaceName: string }>; // incoming parameters
 
-type WorkspaceDetailsState = { activeTabKey: number; workspace: che.IWorkspace; alertVisible: boolean; isDevfileValid: boolean; hasRequestErrors: boolean };
+type WorkspaceDetailsState = { activeTabKey: number; workspace: che.Workspace; alertVisible: boolean; isDevfileValid: boolean; hasRequestErrors: boolean };
 
 class WorkspaceDetails extends React.PureComponent<WorkspaceDetailsProps, WorkspaceDetailsState> {
   private timeoutId: any;
@@ -60,10 +60,10 @@ class WorkspaceDetails extends React.PureComponent<WorkspaceDetailsProps, Worksp
     };
 
     // Toggle currently active tab
-    this.handleTabClick = (event: any, tabIndex: any) => {
+    this.handleTabClick = (event: any, tabIndex: any): void => {
       this.setState({ activeTabKey: tabIndex });
     };
-    this.cancelChanges = (workspaceId: string | undefined) => {
+    this.cancelChanges = (workspaceId: string | undefined): void => {
       clearTimeout(this.timeoutId);
       const workspace = this.props.workspaces.find(workspace => {
         return workspace.id === workspaceId;
@@ -72,21 +72,21 @@ class WorkspaceDetails extends React.PureComponent<WorkspaceDetailsProps, Worksp
         this.setState({ workspace: Object.assign({}, workspace) });
       }
     };
-    this.showAlert = (variant: 'success' | 'danger', title: string, timeDelay?: number) => {
+    this.showAlert = (variant: 'success' | 'danger', title: string, timeDelay?: number): void => {
       this.alert = { variant, title };
       this.setState({ alertVisible: true });
       setTimeout(() => {
         this.setState({ alertVisible: false });
       }, timeDelay ? timeDelay : 2000);
     };
-    this.hideAlert = () => this.setState({ alertVisible: false });
+    this.hideAlert = (): void => this.setState({ alertVisible: false });
   }
 
-  public render() {
+  public render(): React.ReactElement {
     const { workspace, alertVisible } = this.state;
     const workspaceName = workspace.devfile.metadata.name;
 
-    const setCallback = (updateFunction: Function) => {
+    const setCallback = (updateFunction: Function): void => {
       this.cancelFn = updateFunction;
     };
 
@@ -102,7 +102,7 @@ class WorkspaceDetails extends React.PureComponent<WorkspaceDetailsProps, Worksp
         <PageSection variant={SECTION_THEME} className='workspace-details-header'>
           <TextContent>
             <Text component='h1'>
-              Workspaces&nbsp;<b>&nbsp;>&nbsp;</b>&nbsp;{workspaceName}&nbsp;
+              Workspaces&nbsp;<b>&nbsp;&gt;&nbsp;</b>&nbsp;{workspaceName}&nbsp;
                             <WorkspaceIndicator status={workspace.status} /><span>{workspace.status}</span>
             </Text>
           </TextContent>
@@ -127,11 +127,11 @@ class WorkspaceDetails extends React.PureComponent<WorkspaceDetailsProps, Worksp
                 <Text component='h3' className='label'>Workspace</Text>
                 <DevfileEditor devfile={workspace.devfile} setUpdateEditorCallback={setCallback}
                   decorationPattern='location[ \t]*(.*)[ \t]*$'
-                  onChange={(devfile: che.IWorkspaceDevfile, isValid: boolean) => {
+                  onChange={(devfile: che.WorkspaceDevfile, isValid: boolean): void => {
                     this.onDevfileChange(workspace, devfile, isValid);
                   }} />
                 {(!this.state.isDevfileValid || this.state.hasRequestErrors) && (
-                  <Button onClick={() => {
+                  <Button onClick={(): void => {
                     if (this.cancelFn) {
                       this.cancelFn();
                     }
@@ -147,7 +147,7 @@ class WorkspaceDetails extends React.PureComponent<WorkspaceDetailsProps, Worksp
     );
   }
 
-  private onDevfileChange(workspace: che.IWorkspace, newDevfile: che.IWorkspaceDevfile, isValid: boolean): void {
+  private onDevfileChange(workspace: che.Workspace, newDevfile: che.WorkspaceDevfile, isValid: boolean): void {
     this.setState({ isDevfileValid: isValid });
     clearTimeout(this.timeoutId);
     if (!isValid) {
@@ -157,7 +157,7 @@ class WorkspaceDetails extends React.PureComponent<WorkspaceDetailsProps, Worksp
       this.timeoutId = setTimeout(() => {
         const newWorkspace = Object.assign({}, workspace);
         newWorkspace.devfile = newDevfile;
-        this.props.updateWorkspace(newWorkspace).then((workspace: che.IWorkspace) => {
+        this.props.updateWorkspace(newWorkspace).then((workspace: che.Workspace) => {
           this.setState({ hasRequestErrors: false });
           this.setState({ workspace });
           this.showAlert('success', `Workspace has been updated`, 1000);
@@ -173,12 +173,12 @@ class WorkspaceDetails extends React.PureComponent<WorkspaceDetailsProps, Worksp
   }
 
   // TODO rework this temporary solution
-  private sortObject(o: che.IWorkspaceDevfile) {
-    return Object.keys(o).sort().reduce((r, k) => (r[k] = o[k], r), {});
+  private sortObject(o: che.WorkspaceDevfile): che.WorkspaceDevfile {
+    return Object.keys(o).sort().reduce((r, k) => (r[k] = o[k], r), {} as che.WorkspaceDevfile);
   }
 
   // TODO rework this temporary solution
-  private isEqualObject(a: che.IWorkspaceDevfile, b: che.IWorkspaceDevfile) {
+  private isEqualObject(a: che.WorkspaceDevfile, b: che.WorkspaceDevfile): boolean {
     return JSON.stringify(this.sortObject(a)) == JSON.stringify(this.sortObject(b));
   }
 }

--- a/src/services/api/devfiles-registry.ts
+++ b/src/services/api/devfiles-registry.ts
@@ -1,10 +1,10 @@
 import axios from 'axios';
 
-export const fetchDevfiles = (): Promise<{ devfiles: che.IDevfileMetaData[]; registryUrl: string }> => {
-  return axios.get('/api/workspace/settings').then((resp: { data: che.IWorkspaceSettings }) => {
+export const fetchDevfiles = (): Promise<{ devfiles: che.DevfileMetaData[]; registryUrl: string }> => {
+  return axios.get('/api/workspace/settings').then((resp: { data: che.WorkspaceSettings }) => {
     // TODO  remove 'https://che-devfile-registry.openshift.io'. Just for testing.
     const registryUrl = resp && resp.data && resp.data.cheWorkspaceDevfileRegistryUrl || 'https://che-devfile-registry.openshift.io';
-    return axios.get(`${registryUrl}/devfiles/index.json`).then((resp: { data: che.IDevfileMetaData[] }) => {
+    return axios.get(`${registryUrl}/devfiles/index.json`).then((resp: { data: che.DevfileMetaData[] }) => {
       const devfiles = resp.data;
       return axios.get('/api/devfile').then((resp: { data: any }) => {
         const jsonSchema = resp.data;

--- a/src/services/api/workspaces.ts
+++ b/src/services/api/workspaces.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { load } from 'js-yaml';
 
-export const fetchWorkspaces = (): Promise<Array<che.IWorkspace>> => {
+export const fetchWorkspaces = (): Promise<Array<che.Workspace>> => {
   return axios.get('/api/workspace').then(resp => {
     return Promise.resolve(resp.data);
   }).catch(error => {
@@ -9,7 +9,7 @@ export const fetchWorkspaces = (): Promise<Array<che.IWorkspace>> => {
   });
 };
 
-export const startWorkspace = (workspaceId: string): Promise<che.IWorkspace> => {
+export const startWorkspace = (workspaceId: string): Promise<che.Workspace> => {
   return axios.post(`/api/workspace/${workspaceId}/runtime`).then(resp => {
     return Promise.resolve(resp.data);
   }).catch(error => {
@@ -17,7 +17,7 @@ export const startWorkspace = (workspaceId: string): Promise<che.IWorkspace> => 
   });
 };
 
-export const stopWorkspace = (workspaceId: string): Promise<che.IWorkspace> => {
+export const stopWorkspace = (workspaceId: string): Promise<che.Workspace> => {
   return axios.delete(`/api/workspace/${workspaceId}/runtime`).then(resp => {
     return Promise.resolve(resp.data);
   }).catch(error => {
@@ -25,7 +25,7 @@ export const stopWorkspace = (workspaceId: string): Promise<che.IWorkspace> => {
   });
 };
 
-export const deleteWorkspace = (workspaceId: string): Promise<che.IWorkspace> => {
+export const deleteWorkspace = (workspaceId: string): Promise<che.Workspace> => {
   return axios.delete(`/api/workspace/${workspaceId}`).then(resp => {
     return Promise.resolve(resp.data);
   }).catch(error => {
@@ -33,7 +33,7 @@ export const deleteWorkspace = (workspaceId: string): Promise<che.IWorkspace> =>
   });
 };
 
-export const updateWorkspace = (workspace: che.IWorkspace): Promise<che.IWorkspace> => {
+export const updateWorkspace = (workspace: che.Workspace): Promise<che.Workspace> => {
   return axios.put(`/api/workspace/${workspace.id}`, workspace).then(resp => {
     return Promise.resolve(resp.data);
   }).catch(error => {
@@ -41,7 +41,7 @@ export const updateWorkspace = (workspace: che.IWorkspace): Promise<che.IWorkspa
   });
 };
 
-export const createWorkspace = (devfileUrl: string, attr: { [param: string]: string }): Promise<che.IWorkspace> => {
+export const createWorkspace = (devfileUrl: string, attr: { [param: string]: string }): Promise<che.Workspace> => {
   return axios.get(devfileUrl).then(resp => {
     return axios({
       method: 'post',

--- a/src/services/bootstrap/KeycloakSetup.ts
+++ b/src/services/bootstrap/KeycloakSetup.ts
@@ -30,16 +30,16 @@ export class KeycloakSetup {
     keycloak: null,
     config: null
   };
-  private static isDocumentReady: Promise<void> = new Promise<void>((resolve: IResolveFn<void>) => {
+  private static isDocumentReady = new Promise<void>(resolve => {
     const state: IDocumentReadyState = document.readyState;
     if (state === 'interactive' || state === 'complete') {
       resolve();
     } else {
-      document.onreadystatechange = () => resolve();
+      document.onreadystatechange = (): void => resolve();
     }
   });
 
-  private user: che.IUser | {} = {};
+  private user: che.User | {} = {};
 
 
   resolve(): Promise<void> {
@@ -53,7 +53,7 @@ export class KeycloakSetup {
           KeycloakSetup.keycloakAuth.config = this.buildKeycloakConfig(keycloakSettings);
           return new Promise((resolve: IResolveFn<any>, reject: IRejectFn<any>) => {
             const src = keycloakSettings['che.keycloak.js_adapter_url'];
-            const onLoad = () => {
+            const onLoad = (): void => {
               let theUseNonce = false;
               if (typeof keycloakSettings['che.keycloak.use_nonce'] === 'string') {
                 theUseNonce = keycloakSettings['che.keycloak.use_nonce'].toLowerCase() === 'true';
@@ -89,7 +89,7 @@ export class KeycloakSetup {
     });
   };
 
-  getUser(): che.IUser | {} {
+  getUser(): che.User | {} {
     return this.user;
   }
 
@@ -169,7 +169,7 @@ export class KeycloakSetup {
     });
   }
 
-  private addScript(src: string, callbacks: ICallbacks) {
+  private addScript(src: string, callbacks: ICallbacks): void {
     KeycloakSetup.isDocumentReady.then(() => {
       const script = document.createElement('script');
       script.type = 'text/javascript';

--- a/src/services/debounce/Debounce.ts
+++ b/src/services/debounce/Debounce.ts
@@ -10,7 +10,7 @@ export class Debounce {
   private isDebounceDelay = false;
   private debounceDelayHandlers: Array<Function> = [];
 
-  setDelay(timeDelay = 5000) {
+  setDelay(timeDelay = 5000): void {
     this.setDebounceDelay(true);
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
@@ -20,7 +20,7 @@ export class Debounce {
     }, timeDelay);
   }
 
-  private setDebounceDelay(isDebounceDelay: boolean) {
+  private setDebounceDelay(isDebounceDelay: boolean): void {
     this.isDebounceDelay = isDebounceDelay;
     this.debounceDelayHandlers.forEach(handler => {
       if (typeof handler === 'function') {
@@ -37,11 +37,11 @@ export class Debounce {
     this.debounceDelayHandlers.push(handler);
   }
 
-  unsubscribeAll() {
+  unsubscribeAll(): void {
     this.debounceDelayHandlers = [];
   }
 
-  hasDelay() {
+  hasDelay(): boolean {
     return this.isDebounceDelay;
   }
 }

--- a/src/services/deferred.ts
+++ b/src/services/deferred.ts
@@ -15,11 +15,11 @@ export type IDeferred<T> = {
   promise: Promise<T>;
 }
 
-export const getDefer = <T>() => {
+export const getDefer = <T>(): IDeferred<T> => {
   const defer: { [param: string]: any } = {};
   defer.promise = new Promise((resolve: IResolveFn<T>, reject: IRejectFn<any>) => {
     defer.resolve = resolve;
     defer.reject = reject;
   });
-  return <IDeferred<T>>defer;
+  return defer as IDeferred<T>;
 };

--- a/src/services/disposable.ts
+++ b/src/services/disposable.ts
@@ -10,7 +10,10 @@ export class DisposableCollection implements Disposable {
 
   dispose(): void {
     while (this.disposables.length > 0) {
-      this.disposables.pop()!.dispose();
+      const disposable = this.disposables.pop();
+      if (disposable) {
+        disposable.dispose();
+      }
     }
   }
 

--- a/src/services/json-rpc/JsonRpcApiFactory.ts
+++ b/src/services/json-rpc/JsonRpcApiFactory.ts
@@ -17,7 +17,7 @@ export class CheJsonRpcApi {
 
   getJsonRpcMasterApi(entrypoint: string): JsonRpcMasterApi {
     if (this.jsonRpcApiConnection.has(entrypoint)) {
-      return <JsonRpcMasterApi>this.jsonRpcApiConnection.get(entrypoint);
+      return this.jsonRpcApiConnection.get(entrypoint) as JsonRpcMasterApi;
     } else {
       const cheJsonRpcMasterApi: JsonRpcMasterApi = new JsonRpcMasterApi(entrypoint);
       this.jsonRpcApiConnection.set(entrypoint, cheJsonRpcMasterApi);

--- a/src/services/json-rpc/JsonRpcApiService.ts
+++ b/src/services/json-rpc/JsonRpcApiService.ts
@@ -1,4 +1,4 @@
-import { ICommunicationClient, JsonRpcClient } from './JsonRpcClient';
+import { CommunicationClient, JsonRpcClient } from './JsonRpcClient';
 
 /**
  * Class for basic CHE API communication methods.
@@ -11,9 +11,9 @@ export class CheJsonRpcApiClient {
   /**
    * Communication client (can be http, websocket).
    */
-  private client: ICommunicationClient;
+  private client: CommunicationClient;
 
-  constructor(client: ICommunicationClient) {
+  constructor(client: CommunicationClient) {
     this.client = client;
     this.jsonRpcClient = new JsonRpcClient(client);
   }
@@ -35,9 +35,8 @@ export class CheJsonRpcApiClient {
    * @param event event's name to unsubscribe
    * @param notification notification name binded to the event
    * @param handler handler to be removed
-   * @param params params (optional)
    */
-  unsubscribe(event: string, notification: string, handler: Function, params?: any): void {
+  unsubscribe(event: string, notification: string, handler: Function): void {
     this.jsonRpcClient.removeNotificationHandler(notification, handler);
     this.jsonRpcClient.notify(event);
   }

--- a/src/services/json-rpc/JsonRpcClient.ts
+++ b/src/services/json-rpc/JsonRpcClient.ts
@@ -7,7 +7,7 @@ export type CommunicationClientEvent = 'open' | 'message' | 'close' | 'error';
 /**
  * Interface for communication between two entrypoints
  */
-export interface ICommunicationClient {
+export interface CommunicationClient {
   /**
    * Adds listener callbacks for specified client event.
    * @param {CommunicationClientEvent} eventType an event type
@@ -61,7 +61,7 @@ export class JsonRpcClient {
   /**
    * Client for performing communications.
    */
-  private client: ICommunicationClient;
+  private client: CommunicationClient;
   /**
    * The list of the pending requests by request id.
    */
@@ -72,7 +72,7 @@ export class JsonRpcClient {
   private notificationHandlers: Map<string, Array<Function>>;
   private counter = 100;
 
-  constructor(client: ICommunicationClient) {
+  constructor(client: CommunicationClient) {
     this.client = client;
     this.pendingRequests = new Map<string, IDeferred<any>>();
     this.notificationHandlers = new Map<string, Array<Function>>();

--- a/src/services/json-rpc/JsonRpcMasterApi.ts
+++ b/src/services/json-rpc/JsonRpcMasterApi.ts
@@ -1,5 +1,5 @@
 import { CheJsonRpcApiClient } from './JsonRpcApiService';
-import { ICommunicationClient, CommunicationClientEvent } from './JsonRpcClient';
+import { CommunicationClient, CommunicationClientEvent } from './JsonRpcClient';
 import { Keycloak } from '../keycloak/Keycloak';
 import { container } from '../../inversify.config';
 import { WebsocketClient } from "./WebsocketClient";
@@ -17,7 +17,7 @@ const UNSUBSCRIBE = 'unsubscribe';
  */
 export class JsonRpcMasterApi {
   private readonly keycloak: Keycloak;
-  private client: ICommunicationClient;
+  private client: CommunicationClient;
   private cheJsonRpcApi: CheJsonRpcApiClient;
   private clientId: string;
 
@@ -43,7 +43,7 @@ export class JsonRpcMasterApi {
    * @returns {Promise<void>}
    */
   async connect(): Promise<void> {
-    const entryPointProvider = async () => {
+    const entryPointProvider = async (): Promise<string> => {
       const entryPoint = this.entryPoint + (await this.getAuthenticationToken());
       if (this.clientId) {
         let clientId = `clientId=${this.clientId}`;
@@ -68,7 +68,7 @@ export class JsonRpcMasterApi {
     return new Promise(resolve => {
       this.keycloak.updateToken(5).then(() => {
         resolve('?token=' + (window as any)._keycloak.token);
-      }).catch((error: any) => {
+      }).catch(() => {
         resolve('');
       });
     });
@@ -116,7 +116,7 @@ export class JsonRpcMasterApi {
    * @param callback callback to process event
    */
   subscribeWorkspaceStatus(workspaceId: string, callback: Function): void {
-    const statusHandler = (message: any) => {
+    const statusHandler = (message: any): void => {
       if (workspaceId === message.workspaceId) {
         callback(message);
       }
@@ -177,8 +177,7 @@ export class JsonRpcMasterApi {
    */
   private unsubscribe(channel: MasterChannels, workspaceId: string, callback: Function): void {
     const method: string = channel.toString();
-    const params = { method: method, scope: { workspaceId: workspaceId } };
-    this.cheJsonRpcApi.unsubscribe(UNSUBSCRIBE, method, callback, params);
+    this.cheJsonRpcApi.unsubscribe(UNSUBSCRIBE, method, callback);
   }
 
   /**

--- a/src/services/json-rpc/WebsocketClient.ts
+++ b/src/services/json-rpc/WebsocketClient.ts
@@ -1,4 +1,4 @@
-import { CommunicationClientEvent, ICommunicationClient } from './JsonRpcClient';
+import { CommunicationClientEvent, CommunicationClient } from './JsonRpcClient';
 import ReconnectingWebSocket from 'reconnecting-websocket';
 import { getDefer } from '../deferred';
 import { injectable } from 'inversify';
@@ -8,7 +8,7 @@ import { injectable } from 'inversify';
  * JSON RPC through websocket.
  */
 @injectable()
-export class WebsocketClient implements ICommunicationClient {
+export class WebsocketClient implements CommunicationClient {
   private websocketStream: ReconnectingWebSocket;
   private handlers: { [event: string]: Function[] } = {};
 
@@ -18,7 +18,7 @@ export class WebsocketClient implements ICommunicationClient {
    * @param entrypointProvider the entrypoint to connect to
    */
   connect(entrypointProvider: (() => Promise<string>)): Promise<any> {
-    let deferred = getDefer();
+    const deferred = getDefer();
     this.websocketStream = new ReconnectingWebSocket(entrypointProvider, [], {
       connectionTimeout: 60000
     });

--- a/src/store/Branding.ts
+++ b/src/store/Branding.ts
@@ -4,7 +4,11 @@ export interface BrandingState {
   branding: IBranding;
 }
 
-export const setBranding = (branding: IBranding) => {
+export interface BrandingAction extends BrandingState {
+  type: 'SET_BRANDING' | string;
+}
+
+export const setBranding = (branding: IBranding): BrandingAction => {
   return {
     type: 'SET_BRANDING',
     branding: branding
@@ -13,7 +17,7 @@ export const setBranding = (branding: IBranding) => {
 
 const unloadedState: BrandingState = { branding: {} };
 
-const brandingReducer = (state: { branding: IBranding } | undefined = { branding: {} }, action: { type: string; branding: IBranding }) => {
+const brandingReducer = (state: { branding: IBranding } | undefined = { branding: {} }, action: BrandingAction): BrandingState => {
   if (state === undefined) {
     return unloadedState;
   }

--- a/src/store/DevfilesRegistry.ts
+++ b/src/store/DevfilesRegistry.ts
@@ -5,7 +5,7 @@ import { fetchDevfiles } from '../services/api/devfiles-registry';
 // This state defines the type of data maintained in the Redux store.
 export interface DevfilesState {
   isLoading: boolean;
-  data: { devfiles: che.IDevfileMetaData[]; registryUrl: string; jsonSchema?: any }[];
+  data: { devfiles: che.DevfileMetaData[]; registryUrl: string; jsonSchema?: any }[];
 }
 
 interface RequestDevfilesAction {
@@ -14,16 +14,15 @@ interface RequestDevfilesAction {
 
 interface ReceiveDevfilesAction {
   type: 'RECEIVE_DEVFILES';
-  data: { devfiles: che.IDevfileMetaData[]; registryUrl: string }[];
+  data: { devfiles: che.DevfileMetaData[]; registryUrl: string }[];
 }
 
 type KnownAction = RequestDevfilesAction | ReceiveDevfilesAction;
 
-
 // ACTION CREATORS - These are functions exposed to UI components that will trigger a state transition.
 // They don't directly mutate state, but they can have external side-effects (such as loading data).
 export const actionCreators = {
-  requestDevfiles: (): AppThunkAction<KnownAction> => (dispatch, getState) => {
+  requestDevfiles: (): AppThunkAction<KnownAction> => (dispatch, getState): void => {
     const appState = getState();
     if (appState && appState.devfilesRegistry) {
       fetchDevfiles()

--- a/src/store/User.ts
+++ b/src/store/User.ts
@@ -1,15 +1,18 @@
 // This state defines the type of data maintained in the Redux store.
 export interface UserState {
-  user: che.IUser | {};
+  user: che.User | {};
   isLogged: boolean;
+}
+
+export interface UserAction extends UserState {
+  type: string;
 }
 
 export const actionCreators = {
 
 };
 
-
-export const setUser = (user: che.IUser | {}) => {
+export const setUser = (user: che.User | {}): UserAction => {
   return {
     type: 'SET_USER',
     user: user,
@@ -19,7 +22,7 @@ export const setUser = (user: che.IUser | {}) => {
 
 const unloadedState: UserState = { user: { id: '', name: '', email: '' }, isLogged: false };
 
-const userReducer = (state: UserState | undefined, action: { type: string; user: che.IUser; isLogged: boolean }) => {
+const userReducer = (state: UserState | undefined, action: UserAction): UserState => {
   if (state === undefined) {
     return unloadedState;
   }

--- a/src/store/Workspaces.ts
+++ b/src/store/Workspaces.ts
@@ -16,7 +16,7 @@ import { JsonRpcMasterApi } from '../services/json-rpc/JsonRpcMasterApi';
 // This state defines the type of data maintained in the Redux store.
 export interface WorkspacesState {
   isLoading: boolean;
-  workspaces: che.IWorkspace[];
+  workspaces: che.Workspace[];
 }
 
 interface RequestWorkspacesAction {
@@ -29,12 +29,12 @@ interface ReceiveErrorAction {
 
 interface ReceiveWorkspacesAction {
   type: 'RECEIVE_WORKSPACES';
-  workspaces: che.IWorkspace[];
+  workspaces: che.Workspace[];
 }
 
 interface UpdateWorkspaceAction {
   type: 'UPDATE_WORKSPACE';
-  workspace: che.IWorkspace;
+  workspace: che.Workspace;
 }
 
 interface DeleteWorkspaceAction {
@@ -44,7 +44,7 @@ interface DeleteWorkspaceAction {
 
 interface AddWorkspaceAction {
   type: 'ADD_WORKSPACE';
-  workspace: che.IWorkspace;
+  workspace: che.Workspace;
 }
 
 type KnownAction =
@@ -69,14 +69,14 @@ export type IActionCreators = {
   startWorkspace: (workspaceId: string) => any;
   stopWorkspace: (workspaceId: string) => any;
   deleteWorkspace: (workspaceId: string) => any;
-  updateWorkspace: (workspace: che.IWorkspace) => any;
+  updateWorkspace: (workspace: che.Workspace) => any;
   createWorkspace: (devfileUrl: string, attributes: { [param: string]: string }) => any;
 }
 // ACTION CREATORS - These are functions exposed to UI components that will trigger a state transition.
 // They don't directly mutate state, but they can have external side-effects (such as loading data).
 export const actionCreators: IActionCreators = {
 
-  requestWorkspaces: (): AppThunkAction<KnownAction> => (dispatch, getState) => {
+  requestWorkspaces: (): AppThunkAction<KnownAction> => (dispatch, getState): Promise<Array<che.Workspace>> => {
     // Lazy initialization of jsonRpcMasterApi
     if (!jsonRpcMasterApi) {
       jsonRpcMasterApi = cheJsonRpcApi.getJsonRpcMasterApi(jsonRpcApiLocation);
@@ -105,7 +105,7 @@ export const actionCreators: IActionCreators = {
     }
     return Promise.reject();
   },
-  startWorkspace: (workspaceId: string): AppThunkAction<KnownAction> => (dispatch, getState) => {
+  startWorkspace: (workspaceId: string): AppThunkAction<KnownAction> => (dispatch, getState): Promise<che.Workspace> => {
     const appState = getState();
     if (appState && appState.workspaces) {
       const promise = startWorkspace(workspaceId);
@@ -122,7 +122,7 @@ export const actionCreators: IActionCreators = {
     }
     return Promise.reject();
   },
-  stopWorkspace: (workspaceId: string): AppThunkAction<KnownAction> => (dispatch, getState) => {
+  stopWorkspace: (workspaceId: string): AppThunkAction<KnownAction> => (dispatch, getState): Promise<che.Workspace> => {
     const appState = getState();
     if (appState && appState.workspaces) {
       const promise = stopWorkspace(workspaceId);
@@ -139,7 +139,7 @@ export const actionCreators: IActionCreators = {
     }
     return Promise.reject();
   },
-  deleteWorkspace: (workspaceId: string): AppThunkAction<KnownAction> => (dispatch, getState) => {
+  deleteWorkspace: (workspaceId: string): AppThunkAction<KnownAction> => (dispatch, getState): Promise<che.Workspace> => {
     const appState = getState();
     if (appState && appState.workspaces) {
       const promise = deleteWorkspace(workspaceId);
@@ -154,7 +154,7 @@ export const actionCreators: IActionCreators = {
     }
     return Promise.reject();
   },
-  updateWorkspace: (workspace: che.IWorkspace): AppThunkAction<KnownAction> => (dispatch, getState) => {
+  updateWorkspace: (workspace: che.Workspace): AppThunkAction<KnownAction> => (dispatch, getState): Promise<che.Workspace> => {
     const appState = getState();
     if (appState && appState.workspaces) {
       const promise = updateWorkspace(workspace);
@@ -169,7 +169,7 @@ export const actionCreators: IActionCreators = {
     }
     return Promise.reject();
   },
-  createWorkspace: (devfileUrl: string, attr: { [param: string]: string }): AppThunkAction<KnownAction> => (dispatch, getState) => {
+  createWorkspace: (devfileUrl: string, attr: { [param: string]: string }): AppThunkAction<KnownAction> => (dispatch, getState): Promise<che.Workspace> => {
     // Lazy initialization of jsonRpcMasterApi
     if (!jsonRpcMasterApi) {
       jsonRpcMasterApi = cheJsonRpcApi.getJsonRpcMasterApi(jsonRpcApiLocation);
@@ -221,7 +221,7 @@ export const reducer: Reducer<WorkspacesState> = (state: WorkspacesState | undef
       };
     case 'UPDATE_WORKSPACE':
       return {
-        workspaces: state.workspaces.map((workspace: che.IWorkspace) => {
+        workspaces: state.workspaces.map((workspace: che.Workspace) => {
           return workspace.id === action.workspace.id ? action.workspace : workspace;
         }),
         isLoading: false

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -1,10 +1,10 @@
-import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
+import { applyMiddleware, combineReducers, compose, createStore, Store } from 'redux';
 import thunk from 'redux-thunk';
 import { connectRouter, routerMiddleware } from 'connected-react-router';
 import { History } from 'history';
 import { AppState, reducers } from './';
 
-export default function configureStore(history: History, initialState?: AppState) {
+export default function configureStore(history: History, initialState?: AppState): Store {
   const middleware = [
     thunk,
     routerMiddleware(history)

--- a/src/typings/che.d.ts
+++ b/src/typings/che.d.ts
@@ -1,10 +1,6 @@
-declare module 'che' {
-  export = che;
-}
-
 declare namespace che {
 
-  export interface IWorkspace {
+  export interface Workspace {
     id?: string;
     projects?: any;
     links?: {
@@ -14,21 +10,21 @@ declare namespace che {
     temporary?: boolean;
     status?: string;
     namespace?: string;
-    attributes?: IWorkspaceAttributes;
-    devfile: IWorkspaceDevfile;
-    runtime?: IWorkspaceRuntime;
+    attributes?: WorkspaceAttributes;
+    devfile: WorkspaceDevfile;
+    runtime?: WorkspaceRuntime;
     isLocked?: boolean;
     usedResources?: string;
   }
 
-  export interface IWorkspaceSettings {
+  export interface WorkspaceSettings {
     cheWorkspaceDevfileRegistryUrl?: string;
     cheWorkspacePluginRegistryUrl: string;
     'che.workspace.persist_volumes.default': 'false' | 'true';
     supportedRecipeTypes: string;
   }
 
-  export interface IWorkspaceAttributes {
+  export interface WorkspaceAttributes {
     created: number;
     updated?: number;
     stackId?: string;
@@ -39,46 +35,46 @@ declare namespace che {
     [propName: string]: string | number | undefined;
   }
 
-  export interface IWorkspaceConfigAttributes {
+  export interface WorkspaceConfigAttributes {
     persistVolumes?: 'false';
     editor?: string;
     plugins?: string;
   }
 
-  export interface IWorkspaceDevfile {
+  export interface WorkspaceDevfile {
     apiVersion: string;
     components: Array<any>;
     projects?: Array<any>;
     commands?: Array<any>;
-    attributes?: che.IWorkspaceConfigAttributes;
+    attributes?: che.WorkspaceConfigAttributes;
     metadata: {
       name?: string;
       generateName?: string;
     };
   }
 
-  export interface IWorkspaceRuntime {
+  export interface WorkspaceRuntime {
     activeEnv: string;
     links: any[];
     machines: {
-      [machineName: string]: IWorkspaceRuntimeMachine;
+      [machineName: string]: WorkspaceRuntimeMachine;
     };
     owner: string;
-    warnings: IWorkspaceWarning[];
+    warnings: WorkspaceWarning[];
     machineToken?: string;
   }
 
-  export interface IWorkspaceWarning {
+  export interface WorkspaceWarning {
     code?: number;
     message: string;
   }
 
-  export interface IWorkspaceRuntimeMachine {
+  export interface WorkspaceRuntimeMachine {
     attributes: { [propName: string]: string };
-    servers: { [serverName: string]: IWorkspaceRuntimeMachineServer };
+    servers: { [serverName: string]: WorkspaceRuntimeMachineServer };
   }
 
-  export interface IWorkspaceRuntimeMachineServer {
+  export interface WorkspaceRuntimeMachineServer {
     status: string;
     port: string;
     url: string;
@@ -87,7 +83,7 @@ declare namespace che {
     path: string;
   }
 
-  export interface IProjectSource {
+  export interface ProjectSource {
     location: string;
     parameters?: {
       [paramName: string]: any;
@@ -95,21 +91,21 @@ declare namespace che {
     type?: string;
   }
 
-  export interface IProfileAttributes {
+  export interface ProfileAttributes {
     firstName?: string;
     lastName?: string;
 
     [propName: string]: string | number | undefined;
   }
 
-  export interface IProfile {
-    attributes?: IProfileAttributes;
+  export interface Profile {
+    attributes?: ProfileAttributes;
     email: string;
     links?: Array<any>;
     userId: string;
   }
 
-  export interface IUser {
+  export interface User {
     links: any[];
     attributes?: {
       firstName?: string;
@@ -125,7 +121,7 @@ declare namespace che {
     sub?: string;
   }
 
-  export interface IDevfileMetaData {
+  export interface DevfileMetaData {
     displayName: string;
     description?: string;
     globalMemoryLimit: string;
@@ -133,4 +129,8 @@ declare namespace che {
     links: any;
     tags: Array<string>;
   }
+}
+
+declare module 'che' {
+  export = che;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
       "es2015",
       "dom"
     ],
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "types": ["reflect-metadata"],
     "typeRoots": [
       "node_modules/@types"

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -36,17 +36,17 @@ module.exports = {
                         },
                         loader: require.resolve('eslint-loader'),
                     }
-                ]
+                ],
+                exclude: /node_modules/,
             },
             {
                 test: /\.tsx?$/,
-                enforce: 'pre',
                 use: [
                     {
                         loader: 'ts-loader'
                     },
                 ],
-                exclude: /node_modules/
+                exclude: /node_modules/,
             },
             {
                 test: /node_modules[\\\\|\/](yaml-language-server)/,


### PR DESCRIPTION
This PR switches on some of previously disabled `eslint` rules, and provides corresponding fixes.

Following rules are enabled now:
- @typescript-eslint/camelcase
- @typescript-eslint/class-name-casing
- @typescript-eslint/consistent-type-assertions
- @typescript-eslint/explicit-function-return-type
- @typescript-eslint/interface-name-prefix
- @typescript-eslint/no-empty-function
- @typescript-eslint/no-non-null-assertion
- @typescript-eslint/no-this-alias
- @typescript-eslint/no-unused-vars
- @typescript-eslint/no-use-before-define
- @typescript-eslint/no-var-requires
- no-var
- prefer-const
- prefer-rest-params
- prefer-spread
- react/display-name
- react/jsx-no-target-blank
- react/no-find-dom-node
- react/no-unescaped-entities
- react/prop-types

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>