### PR TITLE
Use PatternFly Card component on Get Started page

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Redirect, Route } from 'react-router';
 import { ConnectedRouter as Router } from 'connected-react-router';
 import Layout from './app-nav-menu/Layout';

--- a/src/components/app-common/devfile-editor/DevfileEditor.tsx
+++ b/src/components/app-common/devfile-editor/DevfileEditor.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { AppState } from '../../../store';
 import * as DevfilesRegistry from '../../../store/DevfilesRegistry';
 import { BrandingState } from '../../../store/Branding';
 import { DisposableCollection } from '../../../services/disposable';
-import * as monacoConversion from 'monaco-languageclient/lib/monaco-converter';
+import monacoConversion from 'monaco-languageclient/lib/monaco-converter';
 import * as Monaco from 'monaco-editor-core/esm/vs/editor/editor.main';
 import { language, conf } from 'monaco-languages/release/esm/yaml/yaml';
-import * as yamlLanguageServer from 'yaml-language-server';
+import yamlLanguageServer from 'yaml-language-server';
 import { registerCustomThemes, DEFAULT_CHE_THEME } from './monaco-theme-register';
 import { load, dump } from 'js-yaml';
-import * as $ from 'jquery';
+import $ from 'jquery';
 
 import './devfile-editor.styl';
 

--- a/src/components/app-common/loaders/Loader.tsx
+++ b/src/components/app-common/loaders/Loader.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 
 const Loader = (): React.ReactElement => {

--- a/src/components/app-common/progress/progress.tsx
+++ b/src/components/app-common/progress/progress.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   Progress,
   ProgressMeasureLocation,

--- a/src/components/app-nav-menu/NavMenu.tsx
+++ b/src/components/app-nav-menu/NavMenu.tsx
@@ -1,8 +1,8 @@
 import accessibleStyles from '@patternfly/react-styles/css/utilities/Accessibility/accessibility';
 import '@patternfly/react-core/dist/styles/base.css';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
-import * as Gravatar from 'react-gravatar';
+import Gravatar from 'react-gravatar';
 import { css } from '@patternfly/react-styles';
 import {
   Brand,

--- a/src/components/app-nav-menu/administration/Administration.tsx
+++ b/src/components/app-nav-menu/administration/Administration.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { Gallery, PageSection, Text, TextContent } from "@patternfly/react-core";
 

--- a/src/components/app-nav-menu/dashboard/Dashboard.tsx
+++ b/src/components/app-nav-menu/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import {
   Gallery,

--- a/src/components/app-nav-menu/get-started/SamplesList.tsx
+++ b/src/components/app-nav-menu/get-started/SamplesList.tsx
@@ -1,23 +1,28 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { AppState } from '../../../store';
-import * as DevfilesRegistryStore from '../../../store/DevfilesRegistry';
-import * as WorkspacesStore from '../../../store/Workspaces';
-import CheProgress from '../../app-common/progress/progress';
 import {
+  Alert,
+  AlertActionCloseButton,
+  Brand,
+  Card,
+  CardBody,
+  CardHead,
+  CardHeader,
+  CardHeadMain,
   Gallery,
   PageSection,
   PageSectionVariants,
   Text,
   TextContent,
-  Alert,
-  AlertActionCloseButton
 } from '@patternfly/react-core';
-import { Debounce } from '../../../services/debounce/Debounce';
+import { AppState } from '../../../store';
 import { container } from '../../../inversify.config';
+import { Debounce } from '../../../services/debounce/Debounce';
+import * as DevfilesRegistryStore from '../../../store/DevfilesRegistry';
+import * as WorkspacesStore from '../../../store/Workspaces';
+import CheProgress from '../../app-common/progress/progress';
 
 import './samples-list.styl';
-
 
 // At runtime, Redux will merge together...
 type DevfilesRegistryProps =
@@ -103,20 +108,19 @@ export class SamplesList extends React.PureComponent<DevfilesRegistryProps, { al
           <Gallery gutter='md'>
             {data.map((data: { devfiles: che.DevfileMetaData[]; registryUrl: string }, index: number) => (
               data.devfiles.map((devfile: che.DevfileMetaData, key: number) => (
-                <div
-                  className='pf-c-card pf-m-hoverable pf-m-compact get-started-template'
+                <Card isHoverable isCompact isSelectable
                   key={`${index}_${key}`}
                   onClick={(): void => createWorkspace(data.registryUrl, devfile)}>
-                  <div className='pf-c-card__head'>
-                    <img alt='Icon' src={`${data.registryUrl}${devfile.icon}`} />
-                  </div>
-                  <div className='pf-c-card__header pf-c-title pf-m-md'>
-                    <b>{devfile.displayName}</b>
-                  </div>
-                  <div className='pf-c-card__body'>
-                    {devfile.description}
-                  </div>
-                </div>
+                  <CardHead>
+                    <CardHeadMain>
+                      <Brand src={`${data.registryUrl}${devfile.icon}`}
+                        alt={devfile.displayName}
+                        style={{ height: '64px' }} />
+                    </CardHeadMain>
+                  </CardHead>
+                  <CardHeader>{devfile.displayName}</CardHeader>
+                  <CardBody>{devfile.description}</CardBody>
+                </Card>
               ))
             ))}
           </Gallery>

--- a/src/components/app-nav-menu/get-started/SamplesList.tsx
+++ b/src/components/app-nav-menu/get-started/SamplesList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { AppState } from '../../../store';
 import * as DevfilesRegistryStore from '../../../store/DevfilesRegistry';

--- a/src/components/app-nav-menu/get-started/samples-list.styl
+++ b/src/components/app-nav-menu/get-started/samples-list.styl
@@ -1,6 +1,2 @@
 .get-started-template
   user-select none
-
-  .pf-c-card__head
-    img
-      height 64px

--- a/src/components/app-nav-menu/workspaces/WorkspacesList.tsx
+++ b/src/components/app-nav-menu/workspaces/WorkspacesList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { AppState } from '../../../store';
 import * as WorkspacesStore from '../../../store/Workspaces';

--- a/src/components/app-nav-menu/workspaces/actions/DeleteWorkspace.tsx
+++ b/src/components/app-nav-menu/workspaces/actions/DeleteWorkspace.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { container } from '../../../../inversify.config';
 import { Debounce } from '../../../../services/debounce/Debounce';

--- a/src/components/app-nav-menu/workspaces/actions/WorkspaceStatus.tsx
+++ b/src/components/app-nav-menu/workspaces/actions/WorkspaceStatus.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { Debounce } from '../../../../services/debounce/Debounce';
 import { container } from '../../../../inversify.config';

--- a/src/components/app-nav-menu/workspaces/workspace-indicator/WorkspaceIndicator.tsx
+++ b/src/components/app-nav-menu/workspaces/workspace-indicator/WorkspaceIndicator.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import './workspace-indicator.styl';
 

--- a/src/components/ide-iframe/IdeIframe.tsx
+++ b/src/components/ide-iframe/IdeIframe.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 

--- a/src/components/workspace-details/WorkspaceDetails.tsx
+++ b/src/components/workspace-details/WorkspaceDetails.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 import {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import configureStore from './store/configureStore';
 import { Provider } from 'react-redux';
 import App from './components/App';


### PR DESCRIPTION
The Get Started page in production mode with code splitting enabled:

<img width="945" alt="Screenshot 2020-04-27 at 11 13 48" src="https://user-images.githubusercontent.com/16220722/80349759-63339780-8878-11ea-833d-d0e552c5fc8a.png">


fixes https://github.com/eclipse/che/issues/16740