### PR TITLE
Add docker buildx support for multi-arch images

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -19,13 +19,22 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_FULL: quay.io/che-incubator/che-dashboard-next:next
+      CACHE_IMAGE_FULL: docker.io/cheincubator/che-dashboard-next:cache
 
     steps:
     - name: Checkout che-dashboard-next source code
       uses: actions/checkout@v2
-    - name: Build the Docker image
-      run: docker build . --file apache.Dockerfile --tag ${IMAGE_FULL}
-    - name: Docker Login
+    - name: Docker Buildx
+      uses: crazy-max/ghaction-docker-buildx@v3
+      with:
+        buildx-version: latest
+    - name: Docker prepare
+      run: docker image prune -a -f
+    - name: Docker Quay.io Login
       run: docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
-    - name: Push the Docker image
-      run: docker push ${IMAGE_FULL}
+    - name: Docker docker.io Login
+      run:  docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" docker.io
+    - name: Build and push the Docker image(s)
+      run: docker buildx build --platform linux/amd64,linux/s390x --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" --cache-to="type=registry,ref=${CACHE_IMAGE_FULL},mode=max" -t ${IMAGE_FULL}  -f apache.Dockerfile --push .
+    - name: Docker Logout
+      run: docker logout

--- a/apache.Dockerfile
+++ b/apache.Dockerfile
@@ -13,7 +13,7 @@ FROM docker.io/node:10.20.1 as builder
 COPY package.json /dashboard/
 COPY yarn.lock /dashboard/
 WORKDIR /dashboard
-RUN yarn install --ignore-optional
+RUN yarn --network-timeout 600000 && yarn install --ignore-optional
 COPY . /dashboard/
 RUN yarn compile
 


### PR DESCRIPTION
Signed-off-by: Shahid Shaikh <shahid@us.ibm.com>

Update GitHub Actions for `docker buildx` to support multi-arch docker images.