### PR TITLE
Block scalar literal style in the devfile editor

### DIFF
--- a/src/components/DevfileEditor/index.tsx
+++ b/src/components/DevfileEditor/index.tsx
@@ -155,7 +155,9 @@ export class DevfileEditor extends React.PureComponent<Props, State> {
   }
 
   private stringify(devfile: che.WorkspaceDevfile): string {
-    return safeDump(devfile);
+    return safeDump(devfile, {
+      lineWidth: 9999,
+    });
   }
 
   public componentDidUpdate(): void {


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

This PR makes the devfile editor to use literal style for all block scalars while displaying yaml files.

