### PR TITLE
Improve workspace details page

### DIFF
--- a/.deps/EXCLUDED.md
+++ b/.deps/EXCLUDED.md
@@ -2,7 +2,7 @@
 | --- | --- |
 | `che-dashboard-e2e@1.0.0` | - |
 | `@eclipse-che/api@7.18.1` | - |
-| `@eclipse-che/workspace-client@0.0.1-1598950097` | - |
+| `@eclipse-che/workspace-client@0.0.1-1600695209` | - |
 | `@babel/parser@7.10.2` | [CQ22386](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22386) |
 | `@types/axios@0.14.0` | [CQ22386](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22386) |
 | `@types/react-redux@7.1.9` | [CQ22386](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22386) |

--- a/.deps/dev.md
+++ b/.deps/dev.md
@@ -101,6 +101,7 @@
 | [`@types/prop-types@15.7.3`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/qs@6.9.3`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/range-parser@1.2.3`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | [CQ18717](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18717) |
+| [`@types/react-copy-to-clipboard@4.3.0`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/react-dom@16.9.8`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/react-gravatar@2.6.8`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/react-loadable@5.5.3`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
@@ -110,6 +111,7 @@
 | [`@types/react@16.9.35`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/reactstrap@8.4.2`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/redux-mock-store@1.0.2`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
+| [`@types/reselect@2.2.0`](https://github.com/rackt/reselect) | MIT | clearlydefined |
 | [`@types/serve-static@1.13.4`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | [CQ18717](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18717) |
 | [`@types/sizzle@2.3.2`](https://github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |
 | [`@types/source-list-map@0.1.2`](https://www.github.com/DefinitelyTyped/DefinitelyTyped.git) | MIT | clearlydefined |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -4,7 +4,7 @@
 | --- | --- | --- |
 | [`@babel/runtime@7.10.2`](https://github.com/babel/babel.git) | MIT | clearlydefined |
 | `@eclipse-che/api@7.18.1` | EPL-2.0 | - |
-| [`@eclipse-che/workspace-client@0.0.1-1598950097`](https://github.com/eclipse/che-workspace-client) | EPL-2.0 | - |
+| [`@eclipse-che/workspace-client@0.0.1-1600695209`](https://github.com/eclipse/che-workspace-client) | EPL-2.0 | - |
 | [`@patternfly/patternfly@4.10.31`](https://github.com/patternfly/patternfly.git) | MIT | [CQ22346](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22346) |
 | [`@patternfly/react-core@4.18.5`](https://github.com/patternfly/patternfly-react.git) | MIT | [CQ22347](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22347) |
 | [`@patternfly/react-icons@4.3.5`](https://github.com/patternfly/patternfly-react.git) | MIT | clearlydefined |
@@ -21,6 +21,7 @@
 | [`blueimp-md5@2.16.0`](git://github.com/blueimp/JavaScript-MD5.git) | MIT | clearlydefined |
 | [`classnames@2.2.6`](https://github.com/JedWatson/classnames.git) | MIT | [CQ18717](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18717) |
 | [`connected-react-router@6.8.0`](https://github.com/supasate/connected-react-router.git) | MIT | clearlydefined |
+| [`copy-to-clipboard@3.3.1`](git+https://github.com/sudodoki/copy-to-clipboard) | MIT | clearlydefined |
 | [`core-js@2.6.11`](https://github.com/zloirock/core-js.git) | MIT | clearlydefined |
 | [`create-react-context@0.3.0`](https://github.com/thejameskyle/create-react-context) | MIT | clearlydefined |
 | [`debug@3.1.0`](git://github.com/visionmedia/debug.git) | MIT | [CQ17757](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=17757) |
@@ -91,6 +92,7 @@
 | [`prop-types@15.7.2`](https://github.com/facebook/prop-types.git) | MIT | clearlydefined |
 | [`qs@6.9.4`](https://github.com/ljharb/qs.git) | BSD-3-Clause | clearlydefined |
 | [`querystringify@2.1.1`](https://github.com/unshiftio/querystringify) | MIT | clearlydefined |
+| [`react-copy-to-clipboard@5.0.2`](https://github.com/nkbt/react-copy-to-clipboard.git) | MIT | clearlydefined |
 | [`react-dom@16.13.1`](https://github.com/facebook/react.git) | MIT | clearlydefined |
 | [`react-dropzone@9.0.0`](https://github.com/react-dropzone/react-dropzone.git) | MIT | [CQ22355](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22355) |
 | [`react-is@16.13.1`](https://github.com/facebook/react.git) | MIT | clearlydefined |
@@ -128,6 +130,7 @@
 | [`tiny-invariant@1.1.0`](https://github.com/alexreardon/tiny-invariant.git) | MIT | clearlydefined |
 | [`tiny-warning@1.0.3`](https://github.com/alexreardon/tiny-warning.git) | MIT | clearlydefined |
 | [`tippy.js@5.1.2`](git+https://github.com/atomiks/tippyjs.git) | MIT | clearlydefined |
+| [`toggle-selection@1.0.6`](git+https://github.com/sudodoki/toggle-selection) | MIT | clearlydefined |
 | [`tslib@1.13.0`](https://github.com/Microsoft/tslib.git) | 0BSD | [CQ22357](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22357) |
 | [`tunnel@0.0.6`](https://github.com/koichik/node-tunnel.git) | MIT | clearlydefined |
 | [`type-fest@0.8.1`](https://github.com/sindresorhus/type-fest.git) | (MIT OR CC0-1.0) | clearlydefined |

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "licenseCheck:run": "license-tool/run.sh"
   },
   "dependencies": {
-    "@eclipse-che/workspace-client": "^0.0.1-1598950097",
+    "@eclipse-che/workspace-client": "^0.0.1-1600695209",
     "@patternfly/patternfly": "^4.10.31",
     "@patternfly/react-core": "^4.18.5",
     "@patternfly/react-icons": "^4.3.5",
@@ -54,6 +54,7 @@
     "monaco-languages": "^1.10.0",
     "qs": "^6.9.4",
     "react": "^16.12.0",
+    "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.12.0",
     "react-pluralize": "^1.6.3",
     "react-redux": "^7.1.3",
@@ -74,6 +75,7 @@
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^10.3.0",
     "@types/axios": "^0.14.0",
+    "@types/react-copy-to-clipboard": "^4.3.0",
     "@types/enzyme": "^3.10.5",
     "@types/history": "^4.7.6",
     "@types/jest": "^25.2.3",

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -27,7 +27,7 @@ type Props = {
 export default class Sidebar extends React.PureComponent<Props> {
 
   public render(): React.ReactElement {
-    const { isManaged, isNavOpen, history, theme } = this.props;
+    const { isNavOpen, history, theme } = this.props;
 
     return (
       <PageSidebar

--- a/src/Layout/index.tsx
+++ b/src/Layout/index.tsx
@@ -60,6 +60,7 @@ export class Layout extends React.PureComponent<Props, State> {
     this.setState({
       isSidebarVisible: !this.state.isSidebarVisible,
     });
+    window.postMessage('toggle-navbar', '*');
   }
 
   private changeTheme(theme: ThemeVariant): void {

--- a/src/components/DevfileEditor/stringify.ts
+++ b/src/components/DevfileEditor/stringify.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { safeDump } from 'js-yaml';
+
+const sortOrder: Array<keyof che.WorkspaceDevfile> = ['apiVersion', 'metadata', 'attributes', 'projects', 'components', 'commands'];
+
+const lineWidth = 9999;
+
+function sortKeys(key1: keyof che.WorkspaceDevfile, key2: keyof che.WorkspaceDevfile): -1 | 0 | 1 {
+  const index1 = sortOrder.indexOf(key1);
+  const index2 = sortOrder.indexOf(key2);
+  if (index1 === -1 && index2 === -1) {
+    return 0;
+  }
+  if (index1 === -1) {
+    return 1;
+  }
+  if (index2 === -1) {
+    return -1;
+  }
+  if (index1 < index2) {
+    return -1;
+  }
+  if (index1 > index2) {
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * Provides a devfile stringify function.
+ */
+export default function stringify(devfile: che.WorkspaceDevfile | undefined): string {
+  if (!devfile) {
+    return '';
+  }
+  return safeDump(devfile as che.WorkspaceDevfile, { lineWidth, sortKeys });
+}

--- a/src/components/Progress/Progress.styl
+++ b/src/components/Progress/Progress.styl
@@ -1,6 +1,7 @@
 .progress-line
   display block
   position relative
+  top 1px
   overflow visible
   height 0
   *

--- a/src/containers/WorkspaceDetails.tsx
+++ b/src/containers/WorkspaceDetails.tsx
@@ -21,19 +21,29 @@ import {
   selectIsLoading,
   selectAllWorkspaces,
 } from '../store/Workspaces/selectors';
-import WorkspaceDetailsPage from '../pages/WorkspaceDetails';
+import WorkspaceDetailsPage, { WorkspaceDetailsTabs, WorkspaceDetails as Details } from '../pages/WorkspaceDetails';
+import { AlertVariant } from '@patternfly/react-core';
 
 type Props =
   MappedProps
   & { history: History }
   & RouteComponentProps<{ namespace: string; workspaceName: string }>; // incoming parameters
 
-export class WorkspaceDetails extends React.PureComponent<Props> {
+class WorkspaceDetails extends React.PureComponent<Props> {
+  workspaceDetailsPageRef: React.RefObject<Details>;
+  private showAlert: (variant: AlertVariant.success | AlertVariant.danger, title: string, timeDelay?: number) => void;
 
   constructor(props: Props) {
     super(props);
 
-    const { namespace, workspaceName } = this.props.match.params;
+    this.workspaceDetailsPageRef = React.createRef<Details>();
+    const namespace = this.props.match.params.namespace;
+    const workspaceName = (this.props.match.params.workspaceName.split('&'))[0];
+    if (workspaceName !== this.props.match.params.workspaceName) {
+      const pathname = `/workspace/${namespace}/${workspaceName}`;
+      this.props.history.replace({ pathname });
+    }
+
     const workspace = this.props.allWorkspaces?.find(workspace =>
       workspace.namespace === namespace && workspace.devfile.metadata.name === workspaceName);
     if (workspace) {
@@ -46,14 +56,41 @@ export class WorkspaceDetails extends React.PureComponent<Props> {
     if (!allWorkspaces || allWorkspaces.length === 0) {
       this.props.requestWorkspaces();
     }
+    const showAlert = this.workspaceDetailsPageRef.current?.showAlert;
+    this.showAlert = (variant: AlertVariant.success | AlertVariant.danger, title: string, timeDelay?: number) => {
+      if (showAlert) {
+        showAlert(variant, title, timeDelay);
+      } else {
+        console.error(title);
+      }
+    };
   }
 
   render() {
     return (
       <WorkspaceDetailsPage
-        history={this.props.history}
+        ref={this.workspaceDetailsPageRef}
+        onSave={(workspace: che.Workspace) => this.onSave(workspace)}
       />
     );
+  }
+
+  async onSave(newWorkspaceObj: che.Workspace): Promise<void> {
+    const namespace = newWorkspaceObj.namespace;
+    const workspaceName = newWorkspaceObj.devfile.metadata.name;
+
+    try {
+      await this.props.updateWorkspace(newWorkspaceObj);
+      this.showAlert(AlertVariant.success, 'Workspace has been updated', 2000);
+      const pathname = `/workspace/${namespace}/${workspaceName}`;
+      this.props.history.replace({ pathname });
+      this.props.setWorkspaceId(newWorkspaceObj.id);
+    } catch (e) {
+      if (this.workspaceDetailsPageRef.current?.state.activeTabKey === WorkspaceDetailsTabs.Devfile) {
+        throw new Error(e.toString().replace(/^Error: /gi, ''));
+      }
+      this.showAlert(AlertVariant.danger, 'Failed to update workspace data', 10000);
+    }
   }
 
 }
@@ -65,7 +102,7 @@ const mapStateToProps = (state: AppState) => ({
 
 const connector = connect(
   mapStateToProps,
-  WorkspacesStore.actionCreators
+  WorkspacesStore.actionCreators,
 );
 
 type MappedProps = ConnectedProps<typeof connector>;

--- a/src/pages/WorkspaceDetails/DevfileTab/DevfileTab.styl
+++ b/src/pages/WorkspaceDetails/DevfileTab/DevfileTab.styl
@@ -1,0 +1,26 @@
+.workspace-details
+  height calc(100vh - 380px)
+  width calc(100% - 10px)
+
+.workspace-details-expanded
+  height calc(100vh - 95px)
+  width calc(100% - 40px)
+  position absolute
+  top 0
+
+.workspace-details,
+.workspace-details-expanded
+  background white
+
+  .devfile-header
+    margin 20px 0 5px
+    height 20px
+    padding 0
+
+  .cancel-button
+    margin-right 15px
+
+  .save-button,
+  .cancle-button
+    float right
+    margin-left 5px

--- a/src/pages/WorkspaceDetails/DevfileTab/EditorTools/EditorTools.styl
+++ b/src/pages/WorkspaceDetails/DevfileTab/EditorTools/EditorTools.styl
@@ -1,0 +1,19 @@
+.editor-tools
+  margin 10px 0 5px
+  height 20px
+  & > *
+    height inherit
+    font-size small
+    user-select none
+    float right
+
+  a
+    text-decoration none
+
+  button
+    font-size inherit
+    outline none
+    padding 0
+
+  svg
+    margin-right 8px

--- a/src/pages/WorkspaceDetails/DevfileTab/EditorTools/index.tsx
+++ b/src/pages/WorkspaceDetails/DevfileTab/EditorTools/index.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { Flex, FlexItem, Button, Divider } from '@patternfly/react-core';
+import { CompressIcon, CopyIcon, DownloadIcon, ExpandIcon } from '@patternfly/react-icons/dist/js/icons';
+import CopyToClipboard from 'react-copy-to-clipboard';
+import stringify from '../../../../components/DevfileEditor/stringify';
+
+import './EditorTools.styl';
+
+type Props = {
+  devfile: che.WorkspaceDevfile;
+  handleExpand: (isExpand: boolean) => void;
+};
+
+type State = {
+  copied?: boolean;
+  isExpanded?: boolean;
+};
+
+class EditorTools extends React.PureComponent<Props, State> {
+  private readonly handleExpand: () => void;
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      isExpanded: false,
+    };
+
+    this.handleExpand = () => {
+      if (this.state.isExpanded) {
+        window.postMessage('show-navbar', '*');
+        const isExpanded = false;
+        this.setState({ isExpanded });
+        this.props.handleExpand(isExpanded);
+      } else {
+        window.postMessage('hide-navbar', '*');
+        const isExpanded = true;
+        this.setState({ isExpanded });
+        this.props.handleExpand(isExpanded);
+      }
+    };
+  }
+
+  public render(): React.ReactElement {
+    const devfileText = stringify(this.props.devfile);
+    const devfileBlobUrl = URL.createObjectURL(new Blob([devfileText], { type: 'application/x-yaml' }));
+
+    let copiedTimer;
+    const onCopyToClipboard = () => {
+      this.setState({ copied: true });
+      if (copiedTimer) {
+        clearTimeout(copiedTimer);
+      }
+      copiedTimer = setTimeout(() => {
+        this.setState({ copied: false });
+      }, 3000);
+    };
+
+    return (
+      <div className="editor-tools">
+        <Flex>
+          <FlexItem>
+            <CopyToClipboard text={devfileText} onCopy={() => onCopyToClipboard()}>
+              <Button variant="link">
+                <CopyIcon />{this.state.copied ? 'Copied' : 'Copy to clipboard'}
+              </Button>
+            </CopyToClipboard>
+          </FlexItem>
+          <Divider isVertical />
+          <FlexItem>
+            <a download="devfile.yaml" href={devfileBlobUrl}><DownloadIcon />Download</a>
+          </FlexItem>
+          <Divider isVertical />
+          <FlexItem>
+            <Button variant="link" onClick={() => this.handleExpand()}>
+              {this.state.isExpanded ? (
+                <React.Fragment><CompressIcon />Compress</React.Fragment>
+              ) : (
+                  <React.Fragment><ExpandIcon />Expand</React.Fragment>
+                )}
+            </Button>
+          </FlexItem>
+        </Flex>
+      </div>
+    );
+  }
+}
+
+export default EditorTools;

--- a/src/pages/WorkspaceDetails/DevfileTab/index.tsx
+++ b/src/pages/WorkspaceDetails/DevfileTab/index.tsx
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import {
+  Button,
+  TextContent,
+  Alert,
+  AlertActionCloseButton,
+  AlertVariant,
+  AlertGroup,
+} from '@patternfly/react-core';
+import DevfileEditor, { DevfileEditor as Editor } from '../../../components/DevfileEditor';
+import EditorTools from './EditorTools';
+
+import './DevfileTab.styl';
+
+type Props = {
+  onSave: (workspace: che.Workspace) => Promise<void>;
+  workspace: che.Workspace;
+};
+
+type State = {
+  devfile?: che.WorkspaceDevfile;
+  hasChanges?: boolean;
+  hasRequestErrors?: boolean;
+  currentRequestError?: string;
+  isDevfileValid?: boolean;
+  isExpanded?: boolean;
+  copied?: boolean;
+};
+
+export class EditorTab extends React.PureComponent<Props, State> {
+  private originDevfile: che.WorkspaceDevfile | undefined;
+  private readonly devfileEditorRef: React.RefObject<Editor>;
+
+  cancelChanges: () => void;
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      devfile: Object.assign({}, this.props.workspace?.devfile),
+      hasChanges: false,
+      isDevfileValid: true,
+      hasRequestErrors: false,
+      currentRequestError: '',
+      isExpanded: false,
+    };
+
+    this.cancelChanges = (): void => {
+      this.updateEditor(this.props.workspace?.devfile);
+      this.setState({
+        hasChanges: false,
+        hasRequestErrors: false,
+        currentRequestError: '',
+      });
+    };
+
+    this.devfileEditorRef = React.createRef<Editor>();
+  }
+
+  private init(): void {
+    const devfile = Object.assign({}, this.props.workspace?.devfile as che.WorkspaceDevfile);
+    if (devfile && (!this.originDevfile || !this.isEqualObject(devfile, this.originDevfile))) {
+      this.originDevfile = devfile;
+      this.updateEditor(devfile);
+      this.setState({
+        hasRequestErrors: false,
+        currentRequestError: '',
+        hasChanges: false,
+      });
+    }
+  }
+
+  componentDidMount(): void {
+    this.init();
+  }
+
+  componentDidUpdate(): void {
+    this.init();
+  }
+
+  public render(): React.ReactElement {
+    const originDevfile = this.props.workspace?.devfile as che.WorkspaceDevfile;
+    const { devfile } = this.state;
+
+    return (
+      <React.Fragment>
+        <br />
+        {(this.state.currentRequestError) && (
+          <Alert
+            variant={AlertVariant.danger} isInline title={this.state.currentRequestError}
+            actionClose={<AlertActionCloseButton onClose={() => this.setState({ currentRequestError: '' })} />}
+          />
+        )}
+        <TextContent
+          className={`workspace-details${this.state.isExpanded ? '-expanded' : ''}`}>
+          {(this.state.currentRequestError && this.state.isExpanded) && (
+            <AlertGroup isToast>
+              <Alert
+                variant={AlertVariant.danger}
+                title={this.state.currentRequestError}
+                actionClose={<AlertActionCloseButton onClose={() => this.setState({ currentRequestError: '' })} />}
+              />
+            </AlertGroup>
+          )}
+          <EditorTools devfile={devfile as che.WorkspaceDevfile} handleExpand={isExpanded => {
+            this.setState({ isExpanded });
+          }} />
+          <DevfileEditor
+            ref={this.devfileEditorRef}
+            devfile={originDevfile}
+            decorationPattern="location[ \t]*(.*)[ \t]*$"
+            onChange={(devfile, isValid) => {
+              this.onDevfileChange(devfile, isValid);
+            }}
+          />
+          <Button onClick={() => this.cancelChanges()} variant="secondary" className="cancle-button"
+            isDisabled={!this.state.hasChanges && this.state.isDevfileValid}>
+            Cancel
+          </Button>
+          <Button onClick={async () => await this.onSave()} variant="primary" className="save-button"
+            isDisabled={!this.state.hasChanges || !this.state.isDevfileValid}>
+            Save
+          </Button>
+        </TextContent>
+      </React.Fragment>
+    );
+  }
+
+  private updateEditor(devfile: che.WorkspaceDevfile | undefined): void {
+    if (!devfile) {
+      return;
+    }
+    this.devfileEditorRef.current?.updateContent(devfile);
+    this.setState({ isDevfileValid: true });
+  }
+
+  private onDevfileChange(devfile: che.WorkspaceDevfile, isValid: boolean): void {
+    this.setState({ isDevfileValid: isValid });
+    if (!isValid) {
+      this.setState({ hasChanges: false });
+      return;
+    }
+    if (this.isEqualObject(this.props.workspace.devfile as che.WorkspaceDevfile, devfile)) {
+      this.setState({ hasChanges: false });
+      return;
+    }
+    this.setState({ devfile });
+    this.setState({
+      hasChanges: true,
+      hasRequestErrors: false,
+    });
+  }
+
+  private async onSave(): Promise<void> {
+    const devfile = this.state.devfile;
+    if (!devfile) {
+      return;
+    }
+    const newWorkspaceObj = Object.assign({}, this.props.workspace);
+    newWorkspaceObj.devfile = devfile;
+    this.setState({ hasChanges: false });
+    try {
+      await this.props.onSave(newWorkspaceObj);
+      this.setState({
+        hasChanges: false,
+        hasRequestErrors: false,
+        currentRequestError: '',
+      });
+    } catch (e) {
+      const errorMessage = e.toString().replace(/^Error: /gi, '');
+      this.setState({
+        hasChanges: true,
+        hasRequestErrors: true,
+        currentRequestError: errorMessage,
+      });
+    }
+  }
+
+  private sortObject(obj: che.WorkspaceDevfile): che.WorkspaceDevfile {
+    return Object.keys(obj).sort().reduce((result: che.WorkspaceDevfile, key: string) => {
+      result[key] = obj[key];
+      return result;
+    }, {} as che.WorkspaceDevfile);
+  }
+
+  private isEqualObject(a: che.WorkspaceDevfile, b: che.WorkspaceDevfile): boolean {
+    return JSON.stringify(this.sortObject(a)) == JSON.stringify(this.sortObject(b as che.WorkspaceDevfile));
+  }
+}
+
+export default EditorTab;

--- a/src/pages/WorkspaceDetails/Header/Header.module.css
+++ b/src/pages/WorkspaceDetails/Header/Header.module.css
@@ -1,0 +1,17 @@
+.workspaceDetailsHeader {
+  padding-bottom: 0;
+  user-select: none;
+}
+
+.workspaceDetailsHeader li:first-child {
+  margin-right: 0;
+}
+
+.workspaceDetailsHeader li:first-child a {
+  margin-right: 8px;
+}
+
+.workspaceDetailsHeader h1 {
+  padding-top: 15px;
+  line-height: 25px;
+}

--- a/src/pages/WorkspaceDetails/Header/WorkspaceStatusLabel.module.css
+++ b/src/pages/WorkspaceDetails/Header/WorkspaceStatusLabel.module.css
@@ -1,0 +1,23 @@
+.label {
+  margin-left: 20px;
+  font-size: 20px;
+  text-transform: lowercase;
+  opacity: 0.9;
+}
+
+.rotate {
+  animation-name: spinnerRotate;
+  animation-duration: 1s;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}
+
+@keyframes spinnerRotate {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/pages/WorkspaceDetails/Header/WorkspaceStatusLabel.tsx
+++ b/src/pages/WorkspaceDetails/Header/WorkspaceStatusLabel.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import {
+  BanIcon,
+  ErrorCircleOIcon,
+  InProgressIcon,
+  PauseCircleIcon,
+  ResourcesFullIcon,
+} from '@patternfly/react-icons/dist/js/icons';
+import React from 'react';
+import { Label } from '@patternfly/react-core';
+import { WorkspaceStatus } from '../../../services/api/workspaceStatus';
+
+import styles from './WorkspaceStatusLabel.module.css';
+
+type Props = {
+  status: string | undefined;
+}
+
+class WorkspaceStatusLabel extends React.PureComponent<Props> {
+
+  render(): React.ReactElement {
+    const { status } = this.props;
+
+    let color: 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey';
+
+    switch (status) {
+      case WorkspaceStatus[WorkspaceStatus.STOPPED]:
+        color = 'grey';
+        return (
+          <Label
+            className={styles.label}
+            color={color}
+            icon={<BanIcon color={color} />}
+          >
+            {status}
+          </Label>
+        );
+      case WorkspaceStatus[WorkspaceStatus.RUNNING]:
+        color = 'green';
+        return (
+          <Label
+            className={styles.label}
+            color={color}
+            icon={<ResourcesFullIcon color={color} />}
+          >
+            {status}
+          </Label>
+        );
+      case WorkspaceStatus[WorkspaceStatus.ERROR]:
+        color = 'red';
+        return (
+          <Label
+            className={styles.label}
+            color={color}
+            icon={<ErrorCircleOIcon color={color} />}
+          >
+            {status}
+          </Label>
+        );
+      case WorkspaceStatus[WorkspaceStatus.PAUSED]:
+        color = 'orange';
+        return (
+          <Label
+            className={styles.label}
+            color={color}
+            icon={<PauseCircleIcon color={color} />}
+          >
+            {status}
+          </Label>
+        );
+      default:
+        color = 'blue';
+        return (
+          <Label
+            className={styles.label}
+            color={color}
+            icon={<InProgressIcon className={styles.rotate} color={color} />}
+          >
+            {status}
+          </Label>
+        );
+    }
+  }
+
+}
+
+export default WorkspaceStatusLabel;

--- a/src/pages/WorkspaceDetails/Header/index.tsx
+++ b/src/pages/WorkspaceDetails/Header/index.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { PageSection, Text, TextContent, Label } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import { ROUTE } from '../../../route.enum';
+import { SECTION_THEME } from '../index';
+import WorkspaceStatusLabel from './WorkspaceStatusLabel';
+
+import styles from './Header.module.css';
+
+type Props = {
+  status: string | undefined;
+  workspaceName: string;
+};
+
+class Header extends React.PureComponent<Props> {
+
+  public render(): React.ReactElement {
+    const { workspaceName, status } = this.props;
+
+    return (
+      <PageSection variant={SECTION_THEME} className={styles.workspaceDetailsHeader}>
+        <Breadcrumb>
+          <BreadcrumbItem to={`/#${ROUTE.WORKSPACES}`}>
+            Workspaces
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive>{workspaceName}</BreadcrumbItem>
+        </Breadcrumb>
+        <TextContent>
+          <Text component='h1'>
+            {workspaceName}
+            <WorkspaceStatusLabel status={status} />
+          </Text>
+        </TextContent>
+      </PageSection>
+    );
+  }
+}
+
+export default Header;

--- a/src/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace/index.module.css
+++ b/src/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace/index.module.css
@@ -1,0 +1,16 @@
+/*
+* Copyright (c) 2018-2020 Red Hat, Inc.
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Red Hat, Inc. - initial API and implementation
+*/
+
+.kubernetesNamespace {
+  padding-top: 5px;
+  line-height: 30px;
+}

--- a/src/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace/index.tsx
+++ b/src/pages/WorkspaceDetails/OverviewTab/InfrastructureNamespace/index.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { FormGroup } from '@patternfly/react-core';
+
+import styles from './index.module.css';
+
+type Props = {
+  namespace: string;
+};
+
+class InfrastructureNamespaceFormGroup extends React.PureComponent<Props> {
+
+  public render(): React.ReactElement {
+    return (
+      <FormGroup label="Kubernetes Namespace" fieldId="infrastructure-namespace">
+        <div className={styles.kubernetesNamespace}>
+          {this.props.namespace}
+        </div>
+      </FormGroup>
+    );
+  }
+}
+
+export default InfrastructureNamespaceFormGroup;

--- a/src/pages/WorkspaceDetails/OverviewTab/StorageType/index.module.css
+++ b/src/pages/WorkspaceDetails/OverviewTab/StorageType/index.module.css
@@ -1,0 +1,54 @@
+/*
+* Copyright (c) 2018-2020 Red Hat, Inc.
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Red Hat, Inc. - initial API and implementation
+*/
+
+.storageTypeSelector {
+  max-width: 350px;
+  margin-right: 10px;
+}
+
+.experimentalStorageType {
+  color: #f37943;
+  font-size: 0.8em;
+}
+
+.labelIcon {
+  margin-left: 5px;
+  padding: 0;
+  outline: none;
+}
+
+button.labelIcon {
+  color: inherit;
+}
+
+.storageType {
+  position: relative;
+  top: 2px;
+  color: #3083d6;
+}
+
+.storageType button {
+  bottom: 1px;
+  margin-left: 3px;
+}
+
+.warningAlert h4 {
+  margin-top: 0;
+}
+
+.modalEditStorageType {
+  min-width: 800px;
+}
+
+.modalEditStorageType footer button {
+  margin: 0 0 10px 10px;
+}

--- a/src/pages/WorkspaceDetails/OverviewTab/StorageType/index.tsx
+++ b/src/pages/WorkspaceDetails/OverviewTab/StorageType/index.tsx
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import {
+  FormGroup,
+  Button,
+  Modal,
+  ModalVariant,
+  TextVariants,
+  TextContent,
+  Text,
+  Radio,
+  Alert,
+  AlertVariant,
+} from '@patternfly/react-core';
+import { StorageType } from '../../../../services/types';
+import { AppState } from '../../../../store';
+import { connect, ConnectedProps } from 'react-redux';
+import { OutlinedQuestionCircleIcon, PencilAltIcon } from '@patternfly/react-icons';
+import { selectSettings } from '../../../../store/Workspaces/selectors';
+
+import styles from './index.module.css';
+
+type Props =
+  MappedProps
+  & {
+    storageType?: StorageType;
+    onSave?: (storageType: StorageType) => void;
+  };
+type State = {
+  isSelectorOpen?: boolean;
+  selected?: string;
+  isInfoOpen?: boolean;
+};
+
+export class StorageTypeFormGroup extends React.PureComponent<Props, State> {
+  storageTypes: StorageType[] = [];
+  options: string[] = [];
+  preferredType: string;
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      isSelectorOpen: false,
+      isInfoOpen: false,
+    };
+
+    const settings = this.props.settings;
+    if (settings) {
+      const available_types = settings['che.workspace.storage.available_types'];
+      if (available_types) {
+        this.storageTypes = available_types.split(',') as StorageType[];
+        this.preferredType = settings['che.workspace.storage.preferred_type'];
+        this.storageTypes.forEach(type => {
+          const value = StorageType[type];
+          this.options.push(value);
+        });
+      }
+    }
+  }
+
+  public componentDidUpdate(prevProps: Props): void {
+    if (prevProps.storageType !== this.props.storageType) {
+      const selected = this.props.storageType;
+      this.setState({ selected });
+    }
+  }
+
+  public componentDidMount(): void {
+    const selected = this.props.storageType ? this.props.storageType : this.preferredType;
+    this.setState({ selected });
+  }
+
+  private handleEditToggle(isSelectorOpen: boolean): void {
+    this.setState({ isSelectorOpen });
+  }
+
+  private handleInfoToggle(): void {
+    this.setState(({ isInfoOpen }) => ({
+      isInfoOpen: !isInfoOpen,
+    }));
+  }
+
+  private getExistingTypes(): { hasAsync: boolean, hasPersistent: boolean, hasEphemeral: boolean } {
+    const hasAsync = this.storageTypes.some(type => StorageType[type] === StorageType.async);
+    const hasPersistent = this.storageTypes.some(type => StorageType[type] === StorageType.persistent);
+    const hasEphemeral = this.storageTypes.some(type => StorageType[type] === StorageType.ephemeral);
+
+    return { hasAsync, hasPersistent, hasEphemeral };
+  }
+
+  private getInfoModalContent(): React.ReactNode {
+    const { hasAsync, hasPersistent, hasEphemeral } = this.getExistingTypes();
+
+    const asyncTypeDescr = hasAsync ?
+      (<Text><span className={styles.experimentalStorageType}> Experimental feature </span><br />
+        <b>Asynchronous Storage </b>
+        is combination of Ephemeral and Persistent storages. It allows for faster I / O and keeps your changes,
+        it does backup the workspace on stop and restores it on start.</Text>) : '';
+    const persistentTypeDescr = hasPersistent ?
+      (<Text><b>Persistent Storage</b> is slow I/O but persistent.</Text>) : '';
+    const ephemeralTypeDescr = hasEphemeral ?
+      (<Text><b>Ephemeral Storage</b> allows for faster I/O but may have limited
+        storage and is not persistent.</Text>) : '';
+    const href = this.props.brandingStore.data.docs.storageTypes;
+
+    return (<TextContent>
+      {persistentTypeDescr}
+      {ephemeralTypeDescr}
+      {asyncTypeDescr}
+      <Text><a rel="noreferrer" target="_blank" href={href}>Open documentation page</a></Text>
+    </TextContent>);
+  }
+
+  private getSelectorModal(): React.ReactNode {
+    const { hasAsync, hasPersistent, hasEphemeral } = this.getExistingTypes();
+    const { isSelectorOpen, selected } = this.state;
+    const originSelection = this.props.storageType ? this.props.storageType : this.preferredType;
+
+    const asyncTypeDescr = hasAsync ?
+      (<Text component={TextVariants.h6}><Radio
+        label="Asynchronous" name="asynchronous" id="async-type-radio"
+        description={`Asynchronous this is combination of Ephemeral and Persistent storage. Allows for faster I/O
+         and keeps your changes, will backup on stop and restores on start.`}
+        isChecked={selected === StorageType.async}
+        onChange={() => this.setState({ selected: StorageType.async })}
+      /></Text>) : '';
+    const persistentTypeDescr = hasPersistent ?
+      (<Text component={TextVariants.h6}><Radio
+        label="Persistent" name="persistent" id="persistent-type-radio"
+        description="Persistent Storage slow I/O but persistent."
+        isChecked={selected === StorageType.persistent}
+        onChange={() => this.setState({ selected: StorageType.persistent })}
+      /></Text>) : '';
+    const ephemeralTypeDescr = hasEphemeral ?
+      (<Text component={TextVariants.h6}><Radio
+        label="Ephemeral" name="ephemeral" id="ephemeral-type-radio"
+        description="Ephemeral Storage allows for faster I/O but may have limited storage and is not persistent."
+        isChecked={selected === StorageType.ephemeral}
+        onChange={() => this.setState({ selected: StorageType.ephemeral })}
+      /></Text>) : '';
+
+    return (
+      <Modal variant={ModalVariant.small} isOpen={isSelectorOpen} className={styles.modalEditStorageType}
+        title="Edit Storage Type"
+        onClose={() => this.handleCancelChanges()}
+        actions={[
+          <Button key="confirm" variant="primary" isDisabled={originSelection === selected}
+            onClick={() => this.handleConfirmChanges()}>Save</Button>,
+          <Button key="cancel" variant="secondary" onClick={() => this.handleCancelChanges()}>Cancel</Button>,
+        ]}
+      >
+        <TextContent>
+          <Alert variant={AlertVariant.warning} className={styles.warningAlert}
+            title="Note that after changing the storage type you may lose workspace data." isInline />
+          <Text component={TextVariants.h6}>Select the storage type</Text>
+          {persistentTypeDescr}
+          {ephemeralTypeDescr}
+          {asyncTypeDescr}
+        </TextContent>
+      </Modal>);
+  }
+
+  private handleConfirmChanges(): void {
+    const selection = this.state.selected as StorageType;
+    if (this.props.onSave) {
+      this.props.onSave(selection);
+    }
+    this.setState({
+      selected: selection,
+      isSelectorOpen: false,
+    });
+  }
+
+  private handleCancelChanges(): void {
+    const originSelection = this.props.storageType ? this.props.storageType : this.preferredType;
+    this.setState({ selected: originSelection });
+    this.handleEditToggle(false);
+  }
+
+  public render(): React.ReactNode {
+    const { selected, isInfoOpen } = this.state;
+
+    return (
+      <FormGroup
+        label="Storage Type"
+        fieldId="storage-type"
+        labelIcon={
+          <Button variant="plain" onClick={() => this.handleInfoToggle()} className={styles.labelIcon}>
+            <OutlinedQuestionCircleIcon />
+          </Button>
+        }>
+        <span className={styles.storageType}>
+          {selected}
+          <Button variant="plain" onClick={() => this.handleEditToggle(true)}>
+            <PencilAltIcon />
+          </Button>
+        </span>
+        {this.getSelectorModal()}
+        <Modal title="Storage Type info" variant={ModalVariant.small} isOpen={isInfoOpen} onClose={() => {
+          this.handleInfoToggle();
+        }}>
+          {this.getInfoModalContent()}
+        </Modal>
+      </FormGroup>
+    );
+  }
+}
+
+const mapStateToProps = (state: AppState) => ({
+  brandingStore: state.branding,
+  settings: selectSettings(state),
+});
+
+const connector = connect(
+  mapStateToProps,
+);
+
+type MappedProps = ConnectedProps<typeof connector>;
+export default connector(StorageTypeFormGroup);

--- a/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/__tests__/index.spec.tsx
+++ b/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/__tests__/index.spec.tsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { RenderResult, render, screen, fireEvent } from '@testing-library/react';
+import { WorkspaceNameFormGroup } from '../';
+
+describe('Overview Tab Workspace Name Input', () => {
+
+  const mockOnSave = jest.fn();
+
+  function renderInput(name: string): RenderResult {
+    return render(
+      <WorkspaceNameFormGroup
+        name={name}
+        onSave={mockOnSave}
+      />
+    );
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should show default placeholder', () => {
+    renderInput('new-workspace');
+
+    screen.getByTestId('handle-edit-mode-toggle').click();
+
+    const placeholder = screen.getByPlaceholderText('Enter a workspace name');
+    expect(placeholder).toBeTruthy();
+  });
+
+  it('should show placeholder with generated name', () => {
+    renderInput('');
+
+    screen.getByTestId('handle-edit-mode-toggle').click();
+
+    const textbox = screen.getByRole('textbox');
+    expect(textbox).toBeTruthy();
+
+    const placeholder = textbox.getAttribute('placeholder');
+    expect(placeholder).toMatch('Enter a workspace name');
+  });
+
+  it('should correctly render the component', () => {
+    renderInput('new-workspace');
+
+    screen.getByTestId('handle-edit-mode-toggle').click();
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('new-workspace');
+  });
+
+  it('should correctly re-render the component', () => {
+    const { rerender } = renderInput('name');
+
+    screen.getByTestId('handle-edit-mode-toggle').click();
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('name');
+
+    rerender(
+      (<WorkspaceNameFormGroup
+        name={'new-name'}
+        onSave={mockOnSave}
+      />)
+    );
+
+    expect(input).toHaveValue('new-name');
+  });
+
+  it('should fire onChange event', () => {
+    renderInput('');
+
+    screen.getByTestId('handle-edit-mode-toggle').click();
+
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'new-workspace' } });
+
+    screen.getByTestId('handle-on-save').click();
+
+    expect(mockOnSave).toHaveBeenCalledWith('new-workspace');
+  });
+
+  describe('Overview Tab Workspace Name Validation', () => {
+    let textbox: HTMLInputElement;
+
+    beforeEach(() => {
+      renderInput('new-workspace');
+
+      screen.getByTestId('handle-edit-mode-toggle').click();
+
+      textbox = screen.getByRole('textbox') as HTMLInputElement;
+    });
+
+    it('should handle empty value', () => {
+      fireEvent.change(textbox, { target: { value: '' } });
+      const label = screen.getByText('A value is required.');
+      expect(label).toBeTruthy();
+      expect(textbox).toBeInvalid();
+    });
+
+    it('should handle minimal value length', () => {
+      let label: HTMLElement | null;
+      const message = 'The name has to be at least 3 characters long.';
+
+      const disallowedName1 = 'a';
+
+      fireEvent.change(textbox, { target: { value: disallowedName1 } });
+      label = screen.queryByText(message);
+      expect(label).toBeTruthy();
+      expect(textbox).toBeInvalid();
+
+      const disallowedName2 = 'ab';
+
+      fireEvent.change(textbox, { target: { value: disallowedName2 } });
+      label = screen.queryByText(message);
+      expect(label).toBeTruthy();
+      expect(textbox).toBeInvalid();
+
+      const allowedName = 'abc';
+
+      fireEvent.change(textbox, { target: { value: allowedName } });
+      label = screen.queryByText(message);
+      expect(label).not.toBeTruthy();
+      expect(textbox).toBeValid();
+    });
+
+    it('should handle maximum value length', () => {
+      let label: HTMLElement | null;
+      const message = 'The name is too long. The maximum length is 100 characters.';
+
+      const allowedName = 'a'.repeat(100);
+
+      fireEvent.change(textbox, { target: { value: allowedName } });
+      label = screen.queryByText(message);
+      expect(label).toBeFalsy();
+      expect(textbox).toBeValid();
+
+      const disallowedName = 'a'.repeat(101);
+
+      fireEvent.change(textbox, { target: { value: disallowedName } });
+      label = screen.queryByText(message);
+      expect(label).toBeTruthy();
+      expect(textbox).toBeInvalid();
+    });
+
+    it('should handle pattern mismatch', () => {
+      let label: HTMLElement | null;
+      const message = 'The name can contain digits, latin letters, underscores and it should not contain special characters like space, dollar, etc. It should start and end only with digit or latin letter.';
+
+      const allowedName = 'new-name';
+
+      fireEvent.change(textbox, { target: { value: allowedName } });
+      label = screen.queryByText(message);
+      expect(label).toBeFalsy();
+      expect(textbox).toBeValid();
+
+      const disallowedName1 = 'new*name';
+
+      fireEvent.change(textbox, { target: { value: disallowedName1 } });
+      label = screen.queryByText(message);
+      expect(label).toBeTruthy();
+      expect(textbox).toBeInvalid();
+
+      const disallowedName2 = '-new-name';
+
+      fireEvent.change(textbox, { target: { value: disallowedName2 } });
+      label = screen.queryByText(message);
+      expect(label).toBeTruthy();
+      expect(textbox).toBeInvalid();
+
+      const disallowedName3 = 'new-name-';
+
+      fireEvent.change(textbox, { target: { value: disallowedName3 } });
+      label = screen.queryByText(message);
+      expect(label).toBeTruthy();
+      expect(textbox).toBeInvalid();
+    });
+
+  });
+
+});

--- a/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/index.module.css
+++ b/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/index.module.css
@@ -1,0 +1,26 @@
+/*
+* Copyright (c) 2018-2020 Red Hat, Inc.
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Red Hat, Inc. - initial API and implementation
+*/
+
+.name {
+  position: relative;
+  top: 2px;
+  color: #3083d6;
+}
+
+.name button {
+  bottom: 1px;
+  margin-left: 3px;
+}
+
+.nameInput {
+  max-width: 450px;
+}

--- a/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/index.tsx
+++ b/src/pages/WorkspaceDetails/OverviewTab/WorkspaceName/index.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { Button, FormGroup, InputGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
+import { CheckIcon, ExclamationCircleIcon, PencilAltIcon, TimesIcon } from '@patternfly/react-icons';
+import React from 'react';
+
+import styles from './index.module.css';
+
+const MIN_LENGTH = 3;
+const MAX_LENGTH = 100;
+const PATTERN = `^(?:[a-zA-Z0-9][-_.a-zA-Z0-9]{1,${MAX_LENGTH - 2}}[a-zA-Z0-9])?$`;
+const ERROR_REQUIRED_VALUE = 'A value is required.';
+const ERROR_MIN_LENGTH = `The name has to be at least ${MIN_LENGTH} characters long.`;
+const ERROR_MAX_LENGTH = `The name is too long. The maximum length is ${MAX_LENGTH} characters.`;
+const ERROR_PATTERN_MISMATCH = 'The name can contain digits, latin letters, underscores and it should not contain special characters like space, dollar, etc. It should start and end only with digit or latin letter.';
+
+type Props = {
+  name: string;
+  onSave: (name: string) => void;
+  onChange?: (name: string) => void;
+  callbacks?: { cancelChanges?: () => void }
+};
+
+type State = {
+  errorMessage?: string;
+  name?: string;
+  validated?: ValidatedOptions;
+  isEditMode?: boolean;
+  hasChanges?: boolean;
+};
+
+export class WorkspaceNameFormGroup extends React.PureComponent<Props, State> {
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      name: this.props.name,
+      validated: ValidatedOptions.default,
+      isEditMode: false,
+    };
+
+    if (this.props.callbacks && !this.props.callbacks.cancelChanges) {
+      this.props.callbacks.cancelChanges = () => this.handleCancel();
+    }
+  }
+
+  public componentDidUpdate(prevProps: Props): void {
+    if (prevProps.name !== this.props.name) {
+      this.validate(this.props.name);
+      this.setState({
+        name: this.props.name,
+      });
+      if (this.props.onChange) {
+        this.props.onChange(this.props.name);
+      }
+    }
+  }
+
+  private handleEditModeToggle(): void {
+    this.setState(({ isEditMode }) => ({
+      isEditMode: !isEditMode,
+    }));
+  }
+
+  private handleChange(name: string): void {
+    const hasChanges = name !== this.props.name;
+    this.setState({
+      name,
+      hasChanges,
+    });
+    this.validate(name);
+    if (this.props.onChange) {
+      this.props.onChange(name);
+    }
+  }
+
+  private validate(name: string): void {
+    if (name.length === 0) {
+      this.setState({
+        errorMessage: ERROR_REQUIRED_VALUE,
+        validated: ValidatedOptions.error,
+      });
+      return;
+    } else if (name.length !== 0 && name.length < MIN_LENGTH) {
+      this.setState({
+        errorMessage: ERROR_MIN_LENGTH,
+        validated: ValidatedOptions.error,
+      });
+      return;
+    } else if (name.length > MAX_LENGTH) {
+      this.setState({
+        errorMessage: ERROR_MAX_LENGTH,
+        validated: ValidatedOptions.error,
+      });
+      return;
+    }
+    if (new RegExp(PATTERN).test(name) === false) {
+      this.setState({
+        errorMessage: ERROR_PATTERN_MISMATCH,
+        validated: ValidatedOptions.error,
+      });
+      return;
+    }
+
+    this.setState({
+      errorMessage: undefined,
+      validated: ValidatedOptions.success,
+    });
+  }
+
+  private async handleSave(): Promise<void> {
+    if (this.state.validated !== ValidatedOptions.error) {
+      await this.props.onSave(this.state.name as string);
+      this.setState({
+        validated: ValidatedOptions.default,
+        hasChanges: false,
+      });
+    }
+    this.handleEditModeToggle();
+    if (this.props.onChange) {
+      this.props.onChange(this.props.name);
+    }
+  }
+
+  private handleCancel(): void {
+    this.setState({
+      name: this.props.name,
+      errorMessage: '',
+      validated: ValidatedOptions.default,
+      hasChanges: false,
+    });
+    this.handleEditModeToggle();
+    if (this.props.onChange) {
+      this.props.onChange(this.props.name);
+    }
+  }
+
+  public render(): React.ReactElement {
+    const { name, errorMessage, validated, isEditMode } = this.state;
+    const isSaveButtonDisable = this.state.validated === ValidatedOptions.error || !this.state.hasChanges;
+    const fieldId = 'workspace-name';
+
+    return (
+      <FormGroup
+        label="Workspace Name"
+        isRequired={true}
+        fieldId={fieldId}
+        helperTextInvalid={errorMessage}
+        helperTextInvalidIcon={<ExclamationCircleIcon />}
+        validated={validated}
+      >
+        {(!isEditMode) && (
+          <span className={styles.name}>
+            {name}
+            <Button data-testid="handle-edit-mode-toggle" variant="plain"
+              onClick={() => this.handleEditModeToggle()}>
+              <PencilAltIcon />
+            </Button>
+          </span>
+        )}
+        {(isEditMode) && (
+          <InputGroup className={styles.nameInput}>
+            <TextInput
+              value={name}
+              isRequired
+              type="text"
+              id={fieldId}
+              aria-describedby="workspace-name-helper"
+              name="workspace-name"
+              validated={validated}
+              onChange={_name => this.handleChange(_name)}
+              minLength={MIN_LENGTH}
+              maxLength={MAX_LENGTH}
+              placeholder="Enter a workspace name"
+            />
+            <Button variant="link" data-testid="handle-on-save" isDisabled={isSaveButtonDisable}
+              onClick={() => this.handleSave()}>
+              <CheckIcon />
+            </Button>
+            <Button variant="plain" data-testid="handle-on-cancel" onClick={() => this.handleCancel()}>
+              <TimesIcon />
+            </Button>
+          </InputGroup>
+        )}
+      </FormGroup>
+    );
+  }
+
+}

--- a/src/pages/WorkspaceDetails/OverviewTab/index.tsx
+++ b/src/pages/WorkspaceDetails/OverviewTab/index.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { Form, PageSection, PageSectionVariants } from '@patternfly/react-core';
+import StorageTypeFormGroup from './StorageType';
+import { StorageType } from '../../../services/types';
+import { WorkspaceNameFormGroup } from './WorkspaceName';
+import InfrastructureNamespaceFormGroup from './InfrastructureNamespace';
+
+type Props = {
+  onSave: (workspace: che.Workspace) => Promise<void>;
+  workspace: che.Workspace;
+};
+
+export type State = {
+  storageType: StorageType;
+  namespace: string;
+  workspaceName: string;
+};
+
+export class OverviewTab extends React.Component<Props, State> {
+  private isWorkspaceNameChanged = false;
+  private workspaceNameCallbacks: { cancelChanges?: () => void } = {};
+
+  constructor(props: Props) {
+    super(props);
+
+    const { workspace } = this.props;
+    const storageType = this.getStorageType(workspace.devfile);
+    const workspaceName = workspace.devfile.metadata.name ? workspace.devfile.metadata.name : '';
+    const namespace = workspace.namespace ? workspace.namespace : '';
+
+    this.state = { storageType, workspaceName, namespace };
+  }
+
+  public get hasChanges() {
+    return this.isWorkspaceNameChanged;
+  }
+
+  public cancelChanges(): void {
+    if (this.workspaceNameCallbacks.cancelChanges) {
+      this.workspaceNameCallbacks.cancelChanges();
+    }
+  }
+
+  private async handleWorkspaceNameSave(workspaceName: string): Promise<void> {
+    const newDevfile = Object.assign({}, this.props.workspace.devfile);
+    newDevfile.metadata.name = workspaceName;
+    this.setState({ workspaceName });
+    await this.onSave(newDevfile);
+  }
+
+  private async handleStorageSave(storageType: StorageType): Promise<void> {
+    const newDevfile = Object.assign({}, this.props.workspace.devfile);
+    switch (storageType) {
+      case StorageType.persistent:
+        if (newDevfile.attributes) {
+          delete newDevfile.attributes.persistVolumes;
+          delete newDevfile.attributes.asyncPersist;
+          if (Object.keys(newDevfile.attributes).length === 0) {
+            delete newDevfile.attributes;
+          }
+        }
+        break;
+      case StorageType.ephemeral:
+        if (!newDevfile.attributes) {
+          newDevfile.attributes = {};
+        }
+        newDevfile.attributes.persistVolumes = 'false';
+        delete newDevfile.attributes.asyncPersist;
+        break;
+      case StorageType.async:
+        if (!newDevfile.attributes) {
+          newDevfile.attributes = {};
+        }
+        newDevfile.attributes.persistVolumes = 'false';
+        newDevfile.attributes.asyncPersist = 'true';
+        break;
+    }
+    this.setState({ storageType });
+    await this.onSave(newDevfile);
+  }
+
+  private getStorageType(devfile: che.WorkspaceDevfile): StorageType {
+    let storageType: StorageType;
+    // storage type
+    if (devfile.attributes && devfile.attributes.persistVolumes === 'false') {
+      const isAsync = devfile.attributes && devfile.attributes.asyncPersist === 'true';
+      if (isAsync) {
+        storageType = StorageType.async;
+      } else {
+        storageType = StorageType.ephemeral;
+      }
+    } else {
+      storageType = StorageType.persistent;
+    }
+    return storageType;
+  }
+
+  public render(): React.ReactElement {
+    const devfile = this.props.workspace.devfile;
+    const storageType = this.getStorageType(devfile);
+    const workspaceName = devfile.metadata.name ? devfile.metadata.name : '';
+    const namespace = this.state.namespace;
+
+    return (
+      <React.Fragment>
+        <PageSection
+          variant={PageSectionVariants.light}
+        >
+          <Form isHorizontal onSubmit={e => e.preventDefault()}>
+            <WorkspaceNameFormGroup
+              name={workspaceName}
+              onSave={_workspaceName => this.handleWorkspaceNameSave(_workspaceName)}
+              onChange={_workspaceName => {
+                this.isWorkspaceNameChanged = workspaceName !== _workspaceName;
+              }}
+              callbacks={this.workspaceNameCallbacks}
+            />
+            <InfrastructureNamespaceFormGroup namespace={namespace} />
+            <StorageTypeFormGroup
+              storageType={storageType}
+              onSave={_storageType => this.handleStorageSave(_storageType)}
+            />
+          </Form>
+        </PageSection>
+      </React.Fragment>
+    );
+  }
+
+  private async onSave(devfile: che.WorkspaceDevfile): Promise<void> {
+    const newWorkspaceObj = Object.assign({}, this.props.workspace);
+    newWorkspaceObj.devfile = devfile;
+
+    await this.props.onSave(newWorkspaceObj);
+  }
+
+}
+
+export default OverviewTab;

--- a/src/pages/WorkspaceDetails/WorkspaceDetails.styl
+++ b/src/pages/WorkspaceDetails/WorkspaceDetails.styl
@@ -1,28 +1,6 @@
-.workspace-details-header
-  padding-bottom 0
-  h1
-    margin 0
-    .workspace-status-indicator
-      width 16px
-    .workspace-status-spinner
-      margin 0
-    span
-      text-transform lowercase
-      margin-left 10px
-      font-size 20px
-      opacity .9
 .workspace-details-tabs
   .pf-c-tab-content
     outline none
+
   .pf-c-tabs
     padding-bottom 0
-  .workspace-details-editor
-    height calc(100vh - 290px)
-    width calc(100% - 20px)
-    .label
-      display inline-block
-      width 150px
-      margin-bottom 0
-      font-weight 500
-    .cancel-button
-      float right

--- a/src/pages/WorkspaceDetails/index.tsx
+++ b/src/pages/WorkspaceDetails/index.tsx
@@ -12,118 +12,138 @@
 
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import { History } from 'history';
 import {
   PageSection,
   PageSectionVariants,
-  Text,
-  TextContent,
   Tabs,
   Tab,
-  Button,
   Alert,
   AlertActionCloseButton,
-  AlertGroup
+  AlertGroup,
+  Modal,
+  ModalVariant,
+  AlertVariant,
+  TextContent,
+  Text,
+  Button,
 } from '@patternfly/react-core';
-
-import WorkspaceIndicator from '../../components/Workspace/Indicator';
+import { WorkspaceStatus } from '../../services/api/workspaceStatus';
+import Header from './Header';
 import CheProgress from '../../components/Progress';
 import { AppState } from '../../store';
-import * as WorkspacesStore from '../../store/Workspaces';
-import DevfileEditor, { DevfileEditor as Editor } from '../../components/DevfileEditor';
+import OverviewTab, { OverviewTab as Overview } from './OverviewTab';
+import EditorTab, { EditorTab as Editor } from './DevfileTab';
 import { selectIsLoading, selectWorkspaceById } from '../../store/Workspaces/selectors';
 
 import './WorkspaceDetails.styl';
 
-const SECTION_THEME = PageSectionVariants.light;
+export const SECTION_THEME = PageSectionVariants.light;
+
+export enum WorkspaceDetailsTabs {
+  Overview = 0,
+  Devfile = 4,
+}
 
 type Props =
-  // selectors
   {
-    isLoading: boolean,
-    workspace: che.Workspace | null | undefined,
-  }
-  & { history: History }
-  & MappedProps;
+    onSave: (workspace: che.Workspace) => Promise<void>
+  } & MappedProps;
 
 type State = {
-  activeTabKey: number;
-  workspace: che.Workspace | undefined;
-  alertVisible: boolean;
-  isDevfileValid: boolean;
-  hasRequestErrors: boolean; // todo provide error handling
+  activeTabKey?: WorkspaceDetailsTabs;
+  clickedTabIndex?: WorkspaceDetailsTabs;
+  alertVisible?: boolean;
+  hasWarningMessage?: boolean;
+  hasDiscardChangesMessage?: boolean;
 };
 
-class WorkspaceDetails extends React.PureComponent<Props, State> {
-  private timeoutId: any;
-  private alert: { variant?: 'success' | 'danger'; title?: string } = {};
-  private showAlert: (variant: 'success' | 'danger', title: string, timeDelay?: number) => void;
-  private hideAlert: () => void;
+export class WorkspaceDetails extends React.PureComponent<Props, State> {
+  private alert: { variant?: AlertVariant.success | AlertVariant.danger; title?: string } = {};
+  public showAlert: (variant: AlertVariant.success | AlertVariant.danger, title: string, timeDelay?: number) => void;
+  private readonly hideAlert: () => void;
   private readonly handleTabClick: (event: any, tabIndex: any) => void;
-  private readonly cancelChanges: () => void;
 
-  private devfileEditorRef: React.RefObject<Editor>;
+  private readonly editorTabPageRef: React.RefObject<Editor>;
+  private readonly overviewTabPageRef: React.RefObject<Overview>;
 
-  constructor(props: Props) {
+  constructor(props) {
     super(props);
 
+    this.editorTabPageRef = React.createRef<Editor>();
+    this.overviewTabPageRef = React.createRef<Overview>();
+
     this.state = {
-      workspace: this.props.workspace ? Object.assign({}, this.props.workspace) : undefined,
-      activeTabKey: 4,
+      activeTabKey: 0,
       alertVisible: false,
-      isDevfileValid: true,
-      hasRequestErrors: false
+      hasWarningMessage: false,
+      hasDiscardChangesMessage: false,
     };
 
     // Toggle currently active tab
     this.handleTabClick = (event: any, tabIndex: any): void => {
-      this.setState({ activeTabKey: tabIndex });
+      if ((this.state.activeTabKey === WorkspaceDetailsTabs.Devfile && this.editorTabPageRef.current?.state.hasChanges) ||
+        (this.state.activeTabKey === WorkspaceDetailsTabs.Overview && this.overviewTabPageRef.current?.hasChanges) ||
+        this.props.isLoading) {
+        const focusedElement = (
+          document.hasFocus() &&
+          document.activeElement !== document.body &&
+          document.activeElement !== document.documentElement &&
+          document.activeElement
+        ) || null;
+        if (focusedElement) {
+          (focusedElement as HTMLBaseElement).blur();
+        }
+        if (!this.props.isLoading) {
+          this.setState({ hasDiscardChangesMessage: true, clickedTabIndex: tabIndex });
+        }
+        return;
+      }
+      this.setState({ hasDiscardChangesMessage: false, clickedTabIndex: tabIndex, activeTabKey: tabIndex });
     };
-    this.cancelChanges = (): void => {
-      clearTimeout(this.timeoutId);
-      this.setState({ workspace: Object.assign({}, this.props.workspace) });
-    };
-    this.showAlert = (variant: 'success' | 'danger', title: string, timeDelay?: number): void => {
+    let showAlertTimer;
+    this.showAlert = (variant: AlertVariant.success | AlertVariant.danger, title: string, timeDelay?: number): void => {
       this.alert = { variant, title };
       this.setState({ alertVisible: true });
-      setTimeout(() => {
+      if (showAlertTimer) {
+        clearTimeout(showAlertTimer);
+      }
+      showAlertTimer = setTimeout(() => {
         this.setState({ alertVisible: false });
       }, timeDelay ? timeDelay : 2000);
     };
     this.hideAlert = (): void => this.setState({ alertVisible: false });
-    this.devfileEditorRef = React.createRef<Editor>();
   }
 
   componentDidUpdate(): void {
-    if (
-      this.props.workspace &&
-      (
-        !this.state.workspace ||
-        this.isEqualObject(this.props.workspace.devfile, this.state.workspace?.devfile) === false
-      )
-    ) {
-      this.setState({ workspace: this.props.workspace });
-      this.updateEditor(this.props.workspace.devfile);
+    if (this.props.workspace && (WorkspaceStatus[this.props.workspace?.status] === WorkspaceStatus.STOPPED)) {
+      this.setState({ hasWarningMessage: false });
     }
   }
 
-  private updateEditor(devfile: che.WorkspaceDevfile): void {
-    this.devfileEditorRef.current?.updateContent(devfile);
-    this.setState({ isDevfileValid: true });
+  private handleDiscardChanges(): void {
+    if (this.state.activeTabKey === WorkspaceDetailsTabs.Devfile) {
+      this.editorTabPageRef.current?.cancelChanges();
+    } else if (this.state.activeTabKey === WorkspaceDetailsTabs.Overview) {
+      this.overviewTabPageRef.current?.cancelChanges();
+    }
+
+    const tabIndex = this.state.clickedTabIndex;
+    this.setState({ hasDiscardChangesMessage: false, activeTabKey: tabIndex });
+  }
+
+  private handleCancelChanges(): void {
+    this.setState({ hasDiscardChangesMessage: false });
   }
 
   public render(): React.ReactElement {
-    const { workspace, alertVisible } = this.state;
-
-    if (this.props.isLoading) {
-      return <div>Workspace is loading...</div>;
-    }
+    const { alertVisible } = this.state;
+    const { workspace } = this.props;
 
     if (!workspace) {
       return <div>Workspace not found.</div>;
     }
 
-    const workspaceName = workspace.devfile.metadata.name;
+    const workspaceName = workspace.devfile.metadata.name ? workspace.devfile.metadata.name : '';
 
     return (
       <React.Fragment>
@@ -136,96 +156,65 @@ class WorkspaceDetails extends React.PureComponent<Props, State> {
             />
           </AlertGroup>
         )}
-        <PageSection variant={SECTION_THEME} className='workspace-details-header'>
-          <TextContent>
-            <Text component='h1'>
-              Workspaces&nbsp;<b>&nbsp;&gt;&nbsp;</b>&nbsp;{workspaceName}&nbsp;
-              <WorkspaceIndicator status={workspace.status} />
-              <span>{workspace.status}</span>
-            </Text>
-          </TextContent>
-        </PageSection>
+        <Header workspaceName={workspaceName} status={workspace.status} />
         <PageSection variant={SECTION_THEME} className='workspace-details-tabs'>
+          {(this.state.hasWarningMessage) && (
+            <Alert variant={AlertVariant.warning} isInline
+              title={(<React.Fragment>
+                The workspace <em>{workspaceName}&nbsp;</em> should be restarted to apply changes.
+              </React.Fragment>)}
+              actionClose={(<AlertActionCloseButton
+                onClose={() => this.setState({ hasWarningMessage: false })} />)
+              } />
+          )}
           <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
-            <Tab eventKey={0} title='Overview'>
-              <br /><p>Tab 1 section</p>
+            <Tab eventKey={WorkspaceDetailsTabs.Overview} title={WorkspaceDetailsTabs[WorkspaceDetailsTabs.Overview]}>
+              <CheProgress isLoading={this.props.isLoading} />
+              <OverviewTab
+                ref={this.overviewTabPageRef}
+                workspace={workspace}
+                onSave={workspace => this.onSave(workspace)}
+              />
             </Tab>
-            <Tab eventKey={1} title='Projects'>
-              <br /><p>Tab 2 section</p>
-            </Tab>
-            <Tab eventKey={2} title='Plugins'>
-              <br /><p>Tab 3 section</p>
-            </Tab>
-            <Tab eventKey={3} title='Editors'>
-              <br /><p>Tab 4 section</p>
-            </Tab>
-            <Tab eventKey={4} title='Devfile'>
-              <CheProgress isLoading={this.props.isLoading} /><br />
-              <TextContent className='workspace-details-editor'>
-                <Text component='h3' className='label'></Text>
-                <DevfileEditor
-                  ref={this.devfileEditorRef}
-                  devfile={workspace.devfile}
-                  decorationPattern='location[ \t]*(.*)[ \t]*$'
-                  onChange={(devfile, isValid) => {
-                    this.onDevfileChange(workspace, devfile, isValid);
-                  }}
-                />
-                {(!this.state.isDevfileValid || this.state.hasRequestErrors) && (
-                  <Button onClick={(): void => {
-                    this.updateEditor(workspace.devfile);
-                  }} variant='secondary' className='cancel-button'>
-                    Cancel
-                  </Button>
-                )}
-              </TextContent>
+            <Tab eventKey={WorkspaceDetailsTabs.Devfile} title={WorkspaceDetailsTabs[WorkspaceDetailsTabs.Devfile]}>
+              <CheProgress isLoading={this.props.isLoading} />
+              <EditorTab
+                ref={this.editorTabPageRef}
+                workspace={workspace}
+                onSave={workspace => this.onSave(workspace)} />
             </Tab>
           </Tabs>
+          <Modal variant={ModalVariant.small} isOpen={this.state.hasDiscardChangesMessage}
+            title="Unsaved Changes"
+            onClose={() => this.handleCancelChanges()}
+            actions={[
+              <Button key="confirm" variant="primary" onClick={() => this.handleDiscardChanges()}>
+                Discard Changes
+                   </Button>,
+              <Button key="cancel" variant="secondary" onClick={() => this.handleCancelChanges()}>
+                Cancel
+                   </Button>,
+            ]}
+          >
+            <TextContent>
+              <Text>
+                You have unsaved changes. You may go ahead and discard all changes, or close this window and save them.
+              </Text>
+            </TextContent>
+          </Modal>
         </PageSection>
       </React.Fragment>
     );
   }
 
-  private onDevfileChange(workspace: che.Workspace, newDevfile: che.WorkspaceDevfile, isValid: boolean): void {
-    this.setState({ isDevfileValid: isValid });
-    clearTimeout(this.timeoutId);
-    if (!isValid) {
-      return;
+  private async onSave(workspace: che.Workspace): Promise<void> {
+    if (this.props.workspace && (WorkspaceStatus[this.props.workspace.status] !== WorkspaceStatus.STOPPED)) {
+      this.setState({ hasWarningMessage: true });
     }
-    if (this.isEqualObject(workspace.devfile, newDevfile)) {
-      return;
-    }
-
-    this.timeoutId = setTimeout(async () => {
-      const newWorkspaceObj = Object.assign({}, workspace);
-      newWorkspaceObj.devfile = newDevfile;
-
-      const namespace = newWorkspaceObj.namespace;
-      const workspaceName = newWorkspaceObj.devfile.metadata.name;
-
-      try {
-        await this.props.updateWorkspace(newWorkspaceObj);
-        this.setState({ hasRequestErrors: false });
-        this.showAlert('success', 'Workspace has been updated', 2000);
-
-        const pathname = `/workspace/${namespace}/${workspaceName}`;
-        this.props.history.replace({ pathname });
-      } catch (e) {
-        this.setState({ hasRequestErrors: true });
-        this.showAlert('danger', e, 10000);
-      }
-    }, 2000);
+    await this.props.onSave(workspace);
+    this.editorTabPageRef.current?.cancelChanges();
   }
 
-  // TODO rework this temporary solution
-  private sortObject(o: che.WorkspaceDevfile): che.WorkspaceDevfile {
-    return Object.keys(o).sort().reduce((r, k) => (r[k] = o[k], r), {} as che.WorkspaceDevfile);
-  }
-
-  // TODO rework this temporary solution
-  private isEqualObject(a: che.WorkspaceDevfile, b: che.WorkspaceDevfile): boolean {
-    return JSON.stringify(this.sortObject(a)) == JSON.stringify(this.sortObject(b));
-  }
 }
 
 const mapStateToProps = (state: AppState) => ({
@@ -235,7 +224,9 @@ const mapStateToProps = (state: AppState) => ({
 
 const connector = connect(
   mapStateToProps,
-  WorkspacesStore.actionCreators
+  null,
+  null,
+  { forwardRef: true },
 );
 
 type MappedProps = ConnectedProps<typeof connector>

--- a/src/services/api/workspace.ts
+++ b/src/services/api/workspace.ts
@@ -15,16 +15,6 @@ import * as Qs from 'qs';
 
 const API_WORKSPACE = '/api/workspace';
 
-export async function startWorkspace(workspaceId: string): Promise<che.Workspace> {
-  try {
-    // TODO rework this solution with WorkspaceClient(depends on https://github.com/eclipse/che/issues/17700)
-    const response = await Axios.post<che.Workspace>(`${API_WORKSPACE}/${workspaceId}/runtime`);
-    return response.data;
-  } catch (e) {
-    throw new Error(`Failed to start the workspace with ID: ${workspaceId}, ` + e);
-  }
-}
-
 export async function createWorkspaceFromDevfile(
   devfile: che.WorkspaceDevfile,
   cheNamespace: string | undefined,

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -17,3 +17,9 @@ export interface AlertItem {
   title: string;
   variant: AlertVariant;
 }
+
+export enum StorageType {
+  async = 'Asynchronous',
+  ephemeral = 'Ephemeral',
+  persistent = 'Persistent',
+}

--- a/src/store/Workspaces/index.ts
+++ b/src/store/Workspaces/index.ts
@@ -16,7 +16,6 @@ import { ThunkDispatch } from 'redux-thunk';
 import { AppThunk } from '../';
 import {
   createWorkspaceFromDevfile,
-  startWorkspace,
 } from '../../services/api/workspace';
 import { container } from '../../inversify.config';
 import { CheWorkspaceClient } from '../../services/workspace-client/CheWorkspaceClient';
@@ -200,7 +199,7 @@ export const actionCreators: ActionCreators = {
 
   startWorkspace: (workspaceId: string): AppThunk<KnownAction, Promise<void>> => async (dispatch): Promise<void> => {
     try {
-      const workspace = await startWorkspace(workspaceId);
+      const workspace = await WorkspaceClient.restApiClient.start(workspaceId);
       dispatch({ type: 'UPDATE_WORKSPACE', workspace });
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });
@@ -235,7 +234,8 @@ export const actionCreators: ActionCreators = {
       dispatch({ type: 'UPDATE_WORKSPACE', workspace: updatedWorkspace });
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });
-      throw new Error(`Failed to update the workspace, ID: ${workspace.id}, ` + e);
+      const message = e.response && e.response.data && e.response.data.message ? e.response.data.message : e.message;
+      throw new Error(`Failed to update. ${message}`);
     }
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,10 +466,10 @@
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.18.1.tgz#1beae9ebe694e4b58d0edfefcde07995ce6cd0b2"
   integrity sha512-KnnnDpnxxK0TBgR0Ux3oOYCvmCv6d4cRA+1j9wiLkaJighCqgCUaxnHWXEfolYbRq1+o/sfsxN+BxRDuF+H8wQ==
 
-"@eclipse-che/workspace-client@^0.0.1-1598950097":
-  version "0.0.1-1598950097"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1598950097.tgz#4e341849b74ce9f123952ba7edc3be1005c20f68"
-  integrity sha512-z07pA8MrfSAYZzFnTXifKBAG3w6QxUl0eWVonFxU2lucMq+vFdUI6yPxNgj7dVdm0EeQ1BHZqgnkO1eNaTT1fA==
+"@eclipse-che/workspace-client@^0.0.1-1600695209":
+  version "0.0.1-1600695209"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1600695209.tgz#2b38606e90f71e96bac0f588be26dfd3d66e897e"
+  integrity sha512-7FeRqUvLBdrtpst3oBgzVpdlyX2WZ9ASBQB2nFXV+u6e5TFCzDuCWfuwga8TSEI2Gxz0PUFtbPO0YsGFk7VTrA==
   dependencies:
     "@eclipse-che/api" "^7.0.0-beta-4.0"
     axios "0.19.0"
@@ -1103,6 +1103,13 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/react-copy-to-clipboard@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/react-copy-to-clipboard/-/react-copy-to-clipboard-4.3.0.tgz#8e07becb4f11cfced4bd36038cb5bdf5c2658be5"
+  integrity sha512-iideNPRyroENqsOFh1i2Dv3zkviYS9r/9qD9Uh3Z9NNoAAqqa2x53i7iGndGNnJFIo20wIu7Hgh77tx1io8bgw==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-dom@^16.9.8":
   version "16.9.8"
@@ -2772,6 +2779,13 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+copy-to-clipboard@^3:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
 
 copy-webpack-plugin@^6.0.2:
   version "6.0.2"
@@ -7874,6 +7888,14 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-copy-to-clipboard@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.2.tgz#d82a437e081e68dfca3761fbd57dbf2abdda1316"
+  integrity sha512-/2t5mLMMPuN5GmdXo6TebFa8IoFxZ+KTDDqYhcDm0PhkgEzSxVvIX26G20s1EB02A4h2UZgwtfymZ3lGJm0OLg==
+  dependencies:
+    copy-to-clipboard "^3"
+    prop-types "^15.5.8"
+
 react-dom@^16.12.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
@@ -9655,6 +9677,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What does this PR do?
Rework workspace details components:
- [breadcrumbs component](https://www.patternfly.org/v4/documentation/react/components/breadcrumb) and workspace status component(workspaceDetails header)
- component that handles tabs switching and errors indicating
- dedicated component for each tab content
- buttons to save, cancel changes
- add a warning  message when need to restart for apply changes 

Implement the overview tab.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17899
https://github.com/eclipse/che/issues/16645

![Screenshot from 2020-10-07 13-26-45](https://user-images.githubusercontent.com/6310786/95319630-d2d69580-08a0-11eb-81f9-32a8c6369cd0.png)
![Screenshot from 2020-10-04 03-46-02](https://user-images.githubusercontent.com/6310786/95004689-46ee1080-05f7-11eb-8f01-2167115b6b6e.png)
![Screenshot from 2020-10-04 03-47-41](https://user-images.githubusercontent.com/6310786/95004707-7d2b9000-05f7-11eb-8df5-3e14f2f715eb.png)
![Screenshot from 2020-10-04 03-47-05](https://user-images.githubusercontent.com/6310786/95004708-7f8dea00-05f7-11eb-8ddc-53d082753fe8.png)
![Screenshot from 2020-10-04 03-48-06](https://user-images.githubusercontent.com/6310786/95004711-86b4f800-05f7-11eb-9ff8-e8d0486d1a41.png)
![Screenshot from 2020-10-04 03-50-39](https://user-images.githubusercontent.com/6310786/95004712-8ddc0600-05f7-11eb-9a55-6d876c7e852e.png)


Signed-off-by: Oleksii Orel <oorel@redhat.com>