### PR TITLE
Rework dashboard next image to be based on the current dashboard

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,9 +16,10 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
-      IMAGE_FULL: quay.io/che-incubator/che-dashboard-next:next
+      # Try to find better name to avoid confusion with two next words
+      IMAGE_FULL: quay.io/eclipse/che-dashboard:next-next
 
     steps:
     - name: Checkout che-dashboard-next source code
@@ -30,6 +31,7 @@ jobs:
     - name: Docker prepare
       run: docker image prune -a -f
     - name: Docker Quay.io Login
+      # TODO upload new credentials. Currently che-incubator is used, when eclipse is needed
       run: docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
     - name: Build and push the Docker image(s)
       run: docker buildx build --platform linux/amd64,linux/s390x  -t ${IMAGE_FULL}  -f apache.Dockerfile --push .

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -30,8 +30,7 @@ jobs:
     - name: Docker prepare
       run: docker image prune -a -f
     - name: Docker Quay.io Login
-      # TODO upload new credentials. Currently che-incubator is used, when eclipse is needed
-      run: docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+      run: docker login -u "${{ secrets.QUAY_ECLIPSE_USERNAME }}" -p "${{ secrets.QUAY_ECLIPSE_PASSWORD }}" quay.io
     - name: Build and push the Docker image(s)
       run: docker buildx build --platform linux/amd64,linux/s390x  -t ${IMAGE_FULL}  -f apache.Dockerfile --push .
     - name: Docker Logout

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -18,8 +18,7 @@ jobs:
 
     runs-on: ubuntu-18.04
     env:
-      # Try to find better name to avoid confusion with two next words
-      IMAGE_FULL: quay.io/eclipse/che-dashboard:next-next
+      IMAGE_FULL: quay.io/eclipse/che-dashboard:next-react
 
     steps:
     - name: Checkout che-dashboard-next source code

--- a/apache.Dockerfile
+++ b/apache.Dockerfile
@@ -8,6 +8,9 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
+ARG CHE_DASHBOARD_IMAGE=quay.io/eclipse/che-dashboard
+ARG CHE_DASHBOARD_VERSION=next
+
 FROM docker.io/node:10.20.1 as builder
 
 COPY package.json /dashboard-next/
@@ -17,11 +20,8 @@ RUN yarn --network-timeout 600000 && yarn install --ignore-optional
 COPY . /dashboard-next/
 RUN yarn compile
 
-FROM docker.io/httpd:2.4.43-alpine
-RUN sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/conf/httpd.conf && \
-    sed -i 's|Listen 80|Listen 8080|' /usr/local/apache2/conf/httpd.conf && \
-    mkdir -p /var/www && ln -s /usr/local/apache2/htdocs /var/www/html && \
-    chmod -R g+rwX /usr/local/apache2 && \
-    echo "ServerName localhost" >> /usr/local/apache2/conf/httpd.conf
-COPY --from=builder /dashboard-next/build /usr/local/apache2/htdocs/dashboard
-RUN sed -i -r -e 's#<base href="/">#<base href="/dashboard/"#g'  /usr/local/apache2/htdocs/dashboard/index.html
+FROM ${CHE_DASHBOARD_IMAGE}:${CHE_DASHBOARD_VERSION}
+# TODO Rework Che Server to copy the right folder https://github.com/eclipse/che/blob/master/dockerfiles/che/Dockerfile#L31
+COPY --from=builder /dashboard-next/build /usr/local/apache2/htdocs/dashboard/next
+# TODO Make sure we should remove it
+#RUN sed -i -r -e 's#<base href="/">#<base href="/dashboard/next/"#g'  /usr/local/apache2/htdocs/dashboard/next/index.html

--- a/apache.Dockerfile
+++ b/apache.Dockerfile
@@ -21,7 +21,5 @@ COPY . /dashboard-next/
 RUN yarn compile
 
 FROM ${CHE_DASHBOARD_IMAGE}:${CHE_DASHBOARD_VERSION}
-# TODO Rework Che Server to copy the right folder https://github.com/eclipse/che/blob/master/dockerfiles/che/Dockerfile#L31
+RUN mkdir -p /usr/local/apache2/htdocs/dashboard/next
 COPY --from=builder /dashboard-next/build /usr/local/apache2/htdocs/dashboard/next
-# TODO Make sure we should remove it
-#RUN sed -i -r -e 's#<base href="/">#<base href="/dashboard/next/"#g'  /usr/local/apache2/htdocs/dashboard/next/index.html


### PR DESCRIPTION
### What does this PR do?
Reworks dashboard next image to be based on the current dashboard

Next image github action is tested on https://github.com/che-incubator/che-dashboard-next/pull/71/checks?check_run_id=1384254395

It should be merged after https://github.com/eclipse/che/pull/18332

### Which issue does this PR related to?
https://github.com/eclipse/che/issues/17647#issuecomment-704140948