### PR TITLE
Fix dockerfile used for licence-tool

### DIFF
--- a/license-tool/licenseTool.Dockerfile
+++ b/license-tool/licenseTool.Dockerfile
@@ -12,7 +12,7 @@ FROM docker.io/openjdk:15-jdk
 
 RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
 
-RUN yum install -y git nodejs
+RUN microdnf install -y git nodejs
 
 ARG MAVEN_VERSION=3.6.3
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

It happens that `docker.io/openjdk:15-jdk` doesn't contain `yum` anymore, so `microdnf` is used to install necessary packages.