### PR TITLE
Add test coverage

### DIFF
--- a/.deps/EXCLUDED.md
+++ b/.deps/EXCLUDED.md
@@ -30,7 +30,7 @@
 | `select-hose@2.0.0` | [CQ22386](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22386) |
 | `sshpk@1.16.1` | [CQ22386](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22386) |
 | `stealthy-require@1.1.1` | [CQ22386](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22386) |
-| `typescript@3.9.5` | [CQ22386](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22386) |
+| `typescript@3.9.7` | [CQ22386](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22386) |
 | `watchpack-chokidar2@2.0.0` | [CQ22386](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22386) |
 | `wbuf@1.7.3` | [CQ22386](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22386) |
 | `chokidar@2.1.8` | [CQ21965](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21965) |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,4 +33,4 @@ jobs:
     - name: Build
       run: yarn compile
     - name: Run unit tests
-      run: yarn test --runInBand
+      run: yarn test --coverage --runInBand

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build/
 tests/e2e/dist/
 tests/e2e/node_modules/
 tests/e2e/report/
+
+coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,23 +29,31 @@ module.exports = {
       'tsConfig': 'tsconfig.test.json'
     }
   },
-  coverageThreshold: {
-    global: {
-      branches: 32,
-      functions: 40,
-      lines: 50,
-      statements: 51
-    },
-    './src/components/Header': {
-      branches: 80,
-      functions: 80,
-      lines: 80,
-      statements: 80
-    },
-  },
-  collectCoverage: true,
-  coverageReporters: ['html'],
-  coverageDirectory: './coverage',
   maxWorkers: 4,
   setupFilesAfterEnv: ['./jest.setup.ts'],
+  collectCoverage: false,
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+
+    '!src/**/*.d.{ts,tsx}',
+    '!src/**/*.config.ts',
+    '!src/**/*.enum.ts',
+    '!src/index.tsx',
+    '!src/App.tsx',
+    '!src/Routes.tsx',
+  ],
+  coverageDirectory: './coverage',
+  coverageReporters: [
+    ['html', { coverageDirectory: './coverage_html' }],
+    //['html-spa', {coverageDirectory: './coverage_html-spa' }],
+    'text-summary'
+  ],
+  coverageThreshold: {
+    global: {
+      statements: 29,
+      branches: 18,
+      functions: 24,
+      lines: 29,
+    }
+  },
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,6 +29,23 @@ module.exports = {
       'tsConfig': 'tsconfig.test.json'
     }
   },
+  coverageThreshold: {
+    global: {
+      branches: 32,
+      functions: 40,
+      lines: 50,
+      statements: 51
+    },
+    './src/components/Header': {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80
+    },
+  },
+  collectCoverage: true,
+  coverageReporters: ['html'],
+  coverageDirectory: './coverage',
   maxWorkers: 4,
   setupFilesAfterEnv: ['./jest.setup.ts'],
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "stylelint": "stylelint */**/*.css",
     "stylelint:fix": "stylelint */**/*.css --fix",
     "serve:prod": "webpack-dev-server --color --disable-host-check --config webpack.config.prod-dev.js",
-    "test": "jest --coverage",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "licenseCheck:prepare": "license-tool/build.sh",
     "licenseCheck:run": "license-tool/run.sh"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "stylelint": "stylelint */**/*.css",
     "stylelint:fix": "stylelint */**/*.css --fix",
     "serve:prod": "webpack-dev-server --color --disable-host-check --config webpack.config.prod-dev.js",
-    "test": "jest",
+    "test": "jest --coverage",
     "test:watch": "jest --watch",
     "licenseCheck:prepare": "license-tool/build.sh",
     "licenseCheck:run": "license-tool/run.sh"

--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -223,6 +223,5 @@ const connector = connect(
   mapStateToProps,
   WorkspaceStore.actionCreators,
 );
-// need a different type for testing
-type MappedProps = ConnectedProps<typeof connector> | any
+type MappedProps = ConnectedProps<typeof connector>;
 export default connector(IdeLoader);

--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -223,5 +223,5 @@ const connector = connect(
   mapStateToProps,
   WorkspaceStore.actionCreators,
 );
-type MappedProps = ConnectedProps<typeof connector>;
+type MappedProps = ConnectedProps<typeof connector> | any;
 export default connector(IdeLoader);


### PR DESCRIPTION
### What does this PR do?
These changes bring generation a human-readable HTML coverage report with good navigation per directories. It will help to clarify the current situation with test-coverage.

If test coverage is less than minimal it will reject git-push to upstream.

### Which issue does this PR related to?
https://github.com/eclipse/che/issues/18391  (0 stage)

![Screenshot from 2020-11-18 22-18-04](https://user-images.githubusercontent.com/6310786/99587889-79f73280-29f2-11eb-863c-422c1a4630fc.png)
![Screenshot from 2020-11-18 22-18-32](https://user-images.githubusercontent.com/6310786/99587896-7cf22300-29f2-11eb-8bd6-d6c1bca05c1d.png)

Signed-off-by: Oleksii Orel <oorel@redhat.com>