### PR TITLE
Propogate the full reason for why the workspace failed to start

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "licenseCheck:run": "license-tool/run.sh"
   },
   "dependencies": {
-    "@eclipse-che/workspace-client": "^0.0.1-1604083811",
+    "@eclipse-che/workspace-client": "^0.0.1-1608729566",
     "@patternfly/patternfly": "^4.10.31",
     "@patternfly/react-core": "^4.18.5",
     "@patternfly/react-icons": "^4.3.5",

--- a/src/pages/GetStarted/index.tsx
+++ b/src/pages/GetStarted/index.tsx
@@ -99,16 +99,12 @@ export class GetStarted extends React.PureComponent<Props, State> {
     try {
       workspace = await this.props.createWorkspaceFromDevfile(devfile, undefined, infrastructureNamespace, attr);
     } catch (e) {
-      const errorMessage = 'Failed to create a workspace';
       this.showAlert({
         key: 'new-workspace-failed',
         variant: AlertVariant.danger,
-        title: e.message ? e.message : errorMessage + '.'
+        title: e.message
       });
-      if (e.message) {
-        throw new Error(errorMessage + ', \n' + e.message);
-      }
-      throw new Error(errorMessage + ', \n' + e);
+      throw new Error(e.message);
     }
 
     const workspaceName = workspace.devfile.metadata.name;

--- a/src/pages/GetStarted/index.tsx
+++ b/src/pages/GetStarted/index.tsx
@@ -103,7 +103,7 @@ export class GetStarted extends React.PureComponent<Props, State> {
       this.showAlert({
         key: 'new-workspace-failed',
         variant: AlertVariant.danger,
-        title: e.message ? e.message : errorMessage + '. \n'
+        title: e.message ? e.message : errorMessage + '.'
       });
       if (e.message) {
         throw new Error(errorMessage + ', \n' + e.message);

--- a/src/pages/GetStarted/index.tsx
+++ b/src/pages/GetStarted/index.tsx
@@ -103,8 +103,11 @@ export class GetStarted extends React.PureComponent<Props, State> {
       this.showAlert({
         key: 'new-workspace-failed',
         variant: AlertVariant.danger,
-        title: errorMessage + '.'
+        title: e.message ? e.message : errorMessage + '. \n'
       });
+      if (e.message) {
+        throw new Error(errorMessage + ', \n' + e.message);
+      }
       throw new Error(errorMessage + ', \n' + e);
     }
 

--- a/src/store/Workspaces/index.ts
+++ b/src/store/Workspaces/index.ts
@@ -286,7 +286,7 @@ export const actionCreators: ActionCreators = {
       await WorkspaceClient.restApiClient.stop(workspaceId);
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });
-      throw new Error(e.message);
+      throw new Error(`Failed to stop the workspace, ID: ${workspaceId}, ` + e.message);
     }
   },
 
@@ -297,7 +297,7 @@ export const actionCreators: ActionCreators = {
       dispatch({ type: 'DELETE_WORKSPACE', workspaceId });
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });
-      throw new Error(`Failed to delete the workspace, ID: ${workspaceId}, ` + e);
+      throw new Error(`Failed to delete the workspace, ID: ${workspaceId}, ` + e.message);
     }
   },
 
@@ -331,10 +331,6 @@ export const actionCreators: ActionCreators = {
       return workspace;
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });
-      if (e.response?.data?.message) {
-        // e.response.data.message is set unless the request failed. In which case e.message will hold the error code 
-        throw new Error('Failed to create a new workspace from the devfile: \n' + e.response.data.message);
-      }
       throw new Error('Failed to create a new workspace from the devfile: \n' + e.message);
     }
   },

--- a/src/store/Workspaces/index.ts
+++ b/src/store/Workspaces/index.ts
@@ -333,6 +333,9 @@ export const actionCreators: ActionCreators = {
       return workspace;
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });
+      if (e.response?.data?.message) {
+        throw new Error('Failed to create a new workspace from the devfile: \n' + e.response.data.message);
+      }
       throw new Error('Failed to create a new workspace from the devfile: \n' + e);
     }
   },

--- a/src/store/Workspaces/index.ts
+++ b/src/store/Workspaces/index.ts
@@ -334,9 +334,10 @@ export const actionCreators: ActionCreators = {
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });
       if (e.response?.data?.message) {
+        // e.response.data.message is set unless the request failed. In which case e.message will hold the error code 
         throw new Error('Failed to create a new workspace from the devfile: \n' + e.response.data.message);
       }
-      throw new Error('Failed to create a new workspace from the devfile: \n' + e);
+      throw new Error('Failed to create a new workspace from the devfile: \n' + e.message);
     }
   },
 

--- a/src/store/Workspaces/index.ts
+++ b/src/store/Workspaces/index.ts
@@ -277,9 +277,7 @@ export const actionCreators: ActionCreators = {
       dispatch({ type: 'UPDATE_WORKSPACE', workspace });
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });
-      const statusInfo = e.response && e.response.status ? ` Response code: ${e.response.status}.` : '';
-      const message = e.response && e.response.data && e.response.data.message ? e.response.data.message : e.message;
-      throw new Error(message ? message : `Unknown error happened.${statusInfo} Try again`);
+      throw new Error(e.message);
     }
   },
 
@@ -288,7 +286,7 @@ export const actionCreators: ActionCreators = {
       await WorkspaceClient.restApiClient.stop(workspaceId);
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });
-      throw new Error(`Failed to stop the workspace, ID: ${workspaceId}, ` + e);
+      throw new Error(e.message);
     }
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,13 +466,13 @@
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.18.1.tgz#1beae9ebe694e4b58d0edfefcde07995ce6cd0b2"
   integrity sha512-KnnnDpnxxK0TBgR0Ux3oOYCvmCv6d4cRA+1j9wiLkaJighCqgCUaxnHWXEfolYbRq1+o/sfsxN+BxRDuF+H8wQ==
 
-"@eclipse-che/workspace-client@^0.0.1-1604083811":
-  version "0.0.1-1604083811"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1604083811.tgz#a39b6316775bc4c768ed4a727de113d839d1c5a5"
-  integrity sha512-AdTJSKWiyyEj7yNvbo4cATjaezHzR4xYMZBKjGazo/iGO9cMCjbShoi4VAuXnDYeuMVDk+ZSfPf7/xQ7GDsLBQ==
+"@eclipse-che/workspace-client@^0.0.1-1608729566":
+  version "0.0.1-1608729566"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1608729566.tgz#833fd4ce3b32672a9329973ad10070c4bb78a8ab"
+  integrity sha512-yCWGK+iv3Zs8bLc+3oNho6NEiZ6deCs7MS1/oIGV/Z+edhcmzXWuEWE7BBBlV1kjsx63bnPuSXz4R/JLmD5v3Q==
   dependencies:
     "@eclipse-che/api" "^7.0.0-beta-4.0"
-    axios "0.19.0"
+    axios "0.20.0"
     qs "^6.9.4"
     tunnel "0.0.6"
     websocket "1.0.23"
@@ -1901,13 +1901,12 @@ axios@*, axios@^0.19.2:
   dependencies:
     follow-redirects "1.5.10"
 
-axios@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
-  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+axios@0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
+  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
   dependencies:
-    follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
+    follow-redirects "^1.10.0"
 
 babel-jest@^26.0.1:
   version "26.0.1"
@@ -4214,6 +4213,11 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "^3.0.0"
 
+follow-redirects@^1.10.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
+  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -5141,7 +5145,7 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.0, is-buffer@^2.0.2:
+is-buffer@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==


### PR DESCRIPTION
This PR makes it so that the real reason why a workspace failed to start is propagated back to the user.

Part of: https://github.com/eclipse/che/issues/18554

![2020-12-14-081931_1014x941_scrot](https://user-images.githubusercontent.com/8839537/102086389-03c5d000-3de6-11eb-934d-405770bb7324.png)

to test you need to use: https://github.com/eclipse/che-workspace-client/pull/46

```
cd che-workspace-client
yarn link
cd ../che-dashboard-next
yarn link @eclipse-che/workspace-client
yarn start
```


Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>