### PR TITLE
Propagate the reason why the workspace failed to stop

### DIFF
--- a/src/store/Workspaces/index.ts
+++ b/src/store/Workspaces/index.ts
@@ -288,8 +288,8 @@ export const actionCreators: ActionCreators = {
       await WorkspaceClient.restApiClient.stop(workspaceId);
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });
-      if (e.message) {
-        throw new Error(`Failed to stop the workspace, ID: ${workspaceId}, ` + e.message);
+      if (e.response?.data?.message) {
+        throw new Error(`Failed to stop the workspace, ID: ${workspaceId}, ` + e.response.data.message);
       }
       throw new Error(`Failed to stop the workspace, ID: ${workspaceId}, ` + e);
     }

--- a/src/store/Workspaces/index.ts
+++ b/src/store/Workspaces/index.ts
@@ -288,6 +288,9 @@ export const actionCreators: ActionCreators = {
       await WorkspaceClient.restApiClient.stop(workspaceId);
     } catch (e) {
       dispatch({ type: 'RECEIVE_ERROR' });
+      if (e.message) {
+        throw new Error(`Failed to stop the workspace, ID: ${workspaceId}, ` + e.message);
+      }
       throw new Error(`Failed to stop the workspace, ID: ${workspaceId}, ` + e);
     }
   },


### PR DESCRIPTION
This PR makes it so that when a workspace fails to stop it propagates the error. 

Part of: https://github.com/eclipse/che/issues/18554

I wasn't able to reproduce the 401 issue in the above issue (so this might fix something slightly different). I tested this by starting the workspace, waiting a couple of seconds, stop the workspace, then keep quickly pressing the delete workspace button. This method to reproduce doesn't work every time though

![2020-12-14-142528_1050x720_scrot](https://user-images.githubusercontent.com/8839537/102125563-e0b41400-3e17-11eb-87d6-af9d0e93534d.png)


Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>