### PR TITLE
Implementation of info button and about modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@patternfly/react-table": "^4.5.7",
     "axios": "^0.19.2",
     "connected-react-router": "^6.7.0",
+    "detect-browser": "^5.2.0",
     "gravatar-url": "^3.1.0",
     "history": "^4.10.1",
     "inversify": "^5.0.1",

--- a/src/Layout/Header/Tools/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/Layout/Header/Tools/__tests__/__snapshots__/index.spec.tsx.snap
@@ -10,9 +10,53 @@ exports[`Page header tools should correctly render the component 1`] = `
     <div
       className="pf-c-page__header-tools-item"
     >
+      <nav
+        aria-label="info button"
+        className="pf-c-app-launcher pf-m-align-right"
+        data-ouia-component-id={0}
+        data-ouia-component-type="PF4/Dropdown"
+        data-ouia-safe={true}
+      >
+        <button
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-label="info button"
+          className="pf-c-app-launcher__toggle"
+          disabled={false}
+          id="pf-toggle-id-0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          type="button"
+        >
+          <span
+            className={null}
+          >
+            <svg
+              alt=""
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                transform=""
+              />
+            </svg>
+          </span>
+        </button>
+      </nav>
       <div
         className="pf-c-dropdown pf-m-align-right"
-        data-ouia-component-id={0}
+        data-ouia-component-id={1}
         data-ouia-component-type="PF4/Dropdown"
         data-ouia-safe={true}
       >
@@ -21,7 +65,7 @@ exports[`Page header tools should correctly render the component 1`] = `
           aria-haspopup={true}
           className="pf-c-dropdown__toggle pf-m-plain"
           disabled={false}
-          id="pf-toggle-id-0"
+          id="pf-toggle-id-1"
           onClick={[Function]}
           onKeyDown={[Function]}
           type="button"

--- a/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
+++ b/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
@@ -43,7 +43,7 @@ describe('About modal', () => {
     jest.clearAllMocks();
   });
 
-  // react-test-renderer doesn't have support for portal: https://github.com/facebook/react/issues/11565
+  // todo react-test-renderer doesn't have support for portal: https://github.com/facebook/react/issues/11565
   // which makes this fail
   // it('should correctly render the component', () => {
   //   expect(renderer.create(component).toJSON()).toMatchSnapshot();

--- a/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
+++ b/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AboutModal } from '../about-modal';
+
+jest.mock('../../../../../node_modules/detect-browser/index.js', () => {
+  return {
+    detect: () => {
+      return {
+        name: 'chrome',
+        version: '1.0.0',
+        os: 'linux',
+        type: 'browser'
+      };
+    }
+  };
+});
+
+describe('About modal', () => {
+
+  const closeModal = jest.fn();
+  const component = (<AboutModal
+    productName="Che"
+    productVersion="0.0.1"
+    closeAboutModal={closeModal}
+    isOpen={true}
+    logo="./"
+    username="test-user"
+  />);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // react-test-renderer doesn't have support for portal: https://github.com/facebook/react/issues/11565
+  // which makes this fail
+  // it('should correctly render the component', () => {
+  //   expect(renderer.create(component).toJSON()).toMatchSnapshot();
+  // });
+
+  it('should display username', () => {
+    const { getByText } = render(component);
+    expect(getByText(/username/i)).not.toBeNull();
+    expect(getByText(/test-user/i)).not.toBeNull();
+  });
+
+  it('should display product version', () => {
+    const { getByText } = render(component);
+    expect(getByText(/Che version/i)).not.toBeNull();
+    expect(getByText(/0.0.1/i)).not.toBeNull();
+  });
+
+  it('should display browser version', () => {
+    const { getByText } = render(component);
+    expect(getByText(/Browser version/i)).not.toBeNull();
+    expect(getByText(/1.0.0/i)).not.toBeNull();
+  });
+
+  it('should display browser os', () => {
+    const { getByText } = render(component);
+    expect(getByText(/Browser OS/i)).not.toBeNull();
+    expect(getByText(/Linux/i)).not.toBeNull();
+  });
+});

--- a/src/Layout/Header/Tools/__tests__/index.spec.tsx
+++ b/src/Layout/Header/Tools/__tests__/index.spec.tsx
@@ -41,6 +41,7 @@ describe('Page header tools', () => {
   const mockLogout = jest.fn();
   const mockChangeTheme = jest.fn();
   const mockOnCopyLoginCommand = jest.fn();
+  global.open = jest.fn();
 
   const cheCliTool = 'crwctl';
   const email = 'johndoe@example.com';
@@ -104,6 +105,65 @@ describe('Page header tools', () => {
     fireEvent.click(copyLoginCommandButton);
 
     expect(mockOnCopyLoginCommand).toBeCalled();
+  });
+
+  it('should open the info button', () => {
+    render(component);
+
+    const infoButton = screen.getByRole('button', { name: 'info button' });
+    fireEvent.click(infoButton);
+
+    const items = screen.getAllByRole('menuitem');
+    expect(items.length).toEqual(4);
+  });
+
+  it('should fire the make a wish event', () => {
+    render(component);
+
+    const infoButton = screen.getByRole('button', { name: 'info button' });
+    fireEvent.click(infoButton);
+
+    const makeAWishItem = screen.getByRole('menuitem', { name: /Make a wish/i });
+    fireEvent.click(makeAWishItem);
+
+    expect(global.open).toBeCalled();
+  });
+
+  it('should fire the documentation event', () => {
+    render(component);
+
+    const infoButton = screen.getByRole('button', { name: 'info button' });
+    fireEvent.click(infoButton);
+
+    const documentationItem = screen.getByRole('menuitem', { name: /Documentation/i });
+    fireEvent.click(documentationItem);
+
+    expect(global.open).toBeCalled();
+  });
+
+  it('should fire the community event', () => {
+    render(component);
+
+    const infoButton = screen.getByRole('button', { name: 'info button' });
+    fireEvent.click(infoButton);
+
+    const communityItem = screen.getByRole('menuitem', { name: /Community/i });
+    fireEvent.click(communityItem);
+
+    expect(global.open).toBeCalled();
+  });
+
+  it('should fire the about dropdown event', () => {
+    render(component);
+
+    const infoButton = screen.getByRole('button', { name: 'info button' });
+    fireEvent.click(infoButton);
+
+    const aboutItem = screen.getByRole('menuitem', { name: /About/i });
+    fireEvent.click(aboutItem);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).not.toBeNull();
   });
 
 });

--- a/src/Layout/Header/Tools/__tests__/index.spec.tsx
+++ b/src/Layout/Header/Tools/__tests__/index.spec.tsx
@@ -173,6 +173,8 @@ function createStore(cheCliTool: string): Store {
     .withBranding({
       configuration: {
         cheCliTool
+      },
+      docs: {
       }
     } as BrandingData)
     .build();

--- a/src/Layout/Header/Tools/about-modal.tsx
+++ b/src/Layout/Header/Tools/about-modal.tsx
@@ -50,7 +50,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = (
         <TextList component='dl'>
           {productVersion && (
             <>
-              <TextListItem component='dt'>{productName}</TextListItem>
+              <TextListItem component='dt'>{productName} version</TextListItem>
               <TextListItem component='dd'>
                 <div className='co-select-to-copy'>{productVersion}</div>
               </TextListItem>

--- a/src/Layout/Header/Tools/about-modal.tsx
+++ b/src/Layout/Header/Tools/about-modal.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import * as React from 'react';
+import {
+  AboutModal as PatternflyAboutModal,
+  TextContent,
+  TextList,
+  TextListItem,
+} from '@patternfly/react-core';
+import { detect } from 'detect-browser';
+
+type AboutModalProps = {
+  productName: string | undefined;
+  productVersion: string | undefined;
+  logo: string;
+  isOpen: boolean;
+  closeAboutModal: () => void;
+  username: string | undefined;
+};
+
+type AboutModalItemsProps = {
+  username: string | undefined;
+  productVersion: string | undefined;
+  productName: string | undefined;
+  browserVersion: string | null | undefined;
+  browserOS: string | null | undefined;
+};
+
+const AboutModalItems: React.FC<AboutModalItemsProps> = (
+  props: AboutModalItemsProps
+) => {
+  const productName = props.productName;
+  const productVersion = props.productVersion;
+  const username = props.username;
+  const browserVersion = props.browserVersion;
+  const browserOS = props.browserOS;
+  return (
+    <>
+      <TextContent>
+        <TextList component='dl'>
+          {productVersion && (
+            <>
+              <TextListItem component='dt'>{productName}</TextListItem>
+              <TextListItem component='dd'>
+                <div className='co-select-to-copy'>{productVersion}</div>
+              </TextListItem>
+            </>
+          )}
+          {username && (
+            <>
+              <TextListItem component='dt'>Username</TextListItem>
+              <TextListItem component='dd' className='co-select-to-copy'>
+                {username}
+              </TextListItem>
+            </>
+          )}
+          {browserVersion && (
+            <>
+              <TextListItem component='dt'>Browser Version</TextListItem>
+              <TextListItem component='dd' className='co-select-to-copy'>
+                {browserVersion}
+              </TextListItem>
+            </>
+          )}
+          {browserOS && (
+            <>
+              <TextListItem component='dt'>Browser OS</TextListItem>
+              <TextListItem component='dd' className='co-select-to-copy'>
+                {browserOS}
+              </TextListItem>
+            </>
+          )}
+        </TextList>
+      </TextContent>
+    </>
+  );
+};
+
+export class AboutModal extends React.PureComponent<AboutModalProps> {
+  public render(): React.ReactElement {
+    const { isOpen, closeAboutModal } = this.props;
+    const productName = this.props.productName;
+    const logo = this.props.logo;
+    const productVersion = this.props.productVersion;
+    const userName = this.props.username;
+
+    const browser = detect();
+    const browserVersion = browser?.version;
+    const browserOS = browser?.os;
+
+    return (
+      <PatternflyAboutModal
+        isOpen={isOpen}
+        onClose={closeAboutModal}
+        brandImageSrc={logo}
+        brandImageAlt={`${productName} logo`}
+        noAboutModalBoxContentContainer={true}
+      >
+        <AboutModalItems
+          productVersion={productVersion}
+          username={userName}
+          browserOS={browserOS}
+          browserVersion={browserVersion}
+          productName={productName}
+        />
+      </PatternflyAboutModal>
+    );
+  }
+}

--- a/src/Layout/Header/Tools/index.tsx
+++ b/src/Layout/Header/Tools/index.tsx
@@ -14,6 +14,9 @@ import React from 'react';
 import gravatarUrl from 'gravatar-url';
 import {
   AlertVariant,
+  ApplicationLauncher,
+  ApplicationLauncherGroup,
+  ApplicationLauncherItem,
   Avatar,
   Button,
   ButtonVariant,
@@ -33,6 +36,8 @@ import { KeycloakAuthService } from '../../../services/keycloak/auth';
 import { AppState } from '../../../store';
 import * as InfrastructureNamespaceStore from '../../../store/InfrastructureNamespace';
 import { ThemeVariant } from '../../themeVariant';
+import { QuestionCircleIcon } from '@patternfly/react-icons';
+import { AboutModal } from './about-modal';
 
 import './HeaderTools.styl';
 
@@ -45,30 +50,37 @@ type Props =
     changeTheme: (theme: ThemeVariant) => void;
   };
 type State = {
-  isOpen: boolean;
-}
+  isUsernameDropdownOpen: boolean;
+  isInfoDropdownOpen: boolean;
+  isModalOpen: boolean;
+};
+export class HeaderTools extends React.PureComponent<Props, State> {
 
-class HeaderTools extends React.PureComponent<Props, State> {
   private readonly appAlerts: AppAlerts;
-
   constructor(props: Props) {
     super(props);
 
     this.state = {
-      isOpen: false,
+      isUsernameDropdownOpen: false,
+      isInfoDropdownOpen: false,
+      isModalOpen: false,
     };
 
     this.appAlerts = container.get(AppAlerts);
   }
 
-  private onSelect(): void {
+  private onUsernameSelect(): void {
     this.setState({
-      isOpen: !this.state.isOpen,
+      isUsernameDropdownOpen: !this.state.isUsernameDropdownOpen,
+      isInfoDropdownOpen: false,
     });
   }
 
-  private onToggle(isOpen: boolean): void {
-    this.setState({ isOpen });
+  private onUsernameButtonToggle(isOpen: boolean): void {
+    this.setState({
+      isUsernameDropdownOpen: isOpen,
+      isInfoDropdownOpen: false,
+    });
   }
 
   private setTheme(theme: ThemeVariant): void {
@@ -181,7 +193,7 @@ class HeaderTools extends React.PureComponent<Props, State> {
     this.copyLoginCommand();
   }
 
-  private buildDropdownItems(): Array<React.ReactElement> {
+  private buildUserDropdownItems(): Array<React.ReactElement> {
     return [
       (
         <DropdownItem
@@ -222,45 +234,145 @@ class HeaderTools extends React.PureComponent<Props, State> {
     ];
   }
 
-  private buildToggleButton(): React.ReactElement {
-    const userName = this.props.user?.name || '';
-
+  private buildUserToggleButton(): React.ReactElement {
     return (
-      <DropdownToggle onToggle={isOpen => this.onToggle(isOpen)}>
-        {userName}
+      <DropdownToggle
+        onToggle={(isOpen) => this.onUsernameButtonToggle(isOpen)}
+      >
+        {this.props.user?.name}
       </DropdownToggle>
     );
   }
 
+  private onInfoDropdownToggle() {
+    this.setState({
+      isInfoDropdownOpen: !this.state.isInfoDropdownOpen,
+      isUsernameDropdownOpen: false,
+    });
+  }
+
+  private buildInfoDropdownItems(): React.ReactNode[] {
+    const branding = this.props.branding.data;
+    const makeAWish = 'mailto:che-dev@eclipse.org?subject=Wishes%20for%20';
+    const faq = branding.docs.faq;
+    const generalDocs = branding.docs.general;
+    const community = 'https://www.eclipse.org/che/';
+    return [
+      <ApplicationLauncherGroup key='info_button'>
+        <ApplicationLauncherItem
+          key='make_a_wish'
+          isExternal={true}
+          component='button'
+          onClick={() => window.open(makeAWish, '_blank')}
+        >
+          Make a wish
+        </ApplicationLauncherItem>
+        <ApplicationLauncherItem
+          key='documention'
+          isExternal={true}
+          component='button'
+          onClick={() => window.open(generalDocs, '_blank')}
+        >
+          Documentation
+        </ApplicationLauncherItem>
+        {faq && (
+          <ApplicationLauncherItem
+            key='faq'
+            isExternal={true}
+            onClick={() => window.open(faq, '_blank')}
+            component='button'
+          >
+            FAQ
+          </ApplicationLauncherItem>
+        )}
+        <ApplicationLauncherItem
+          key='community'
+          isExternal={true}
+          component='button'
+          onClick={() => window.open(community, '_target')}
+        >
+          Community
+        </ApplicationLauncherItem>
+        <ApplicationLauncherItem
+          key='about'
+          component='button'
+          onClick={(e) => this.onAboutModal(e)}
+        >
+          About
+        </ApplicationLauncherItem>
+      </ApplicationLauncherGroup>,
+    ];
+  }
+
+  private onAboutModal(e) {
+    e.preventDefault();
+    this.setState({
+      isInfoDropdownOpen: false,
+      isUsernameDropdownOpen: false,
+      isModalOpen: true,
+    });
+  }
+
+  private closeAboutModal() {
+    this.setState({
+      isInfoDropdownOpen: false,
+      isUsernameDropdownOpen: false,
+      isModalOpen: false,
+    });
+  }
+
   public render(): React.ReactElement {
-    const { isOpen } = this.state;
+    const {
+      isUsernameDropdownOpen,
+      isInfoDropdownOpen,
+      isModalOpen,
+    } = this.state;
 
     const userEmail = this.props.user?.email || '';
     const imageUrl = gravatarUrl(userEmail, { default: 'retro' });
     const avatar = <Avatar src={imageUrl} alt='Avatar image' />;
 
-    const toggleButton = this.buildToggleButton();
-    const dropdownItems = this.buildDropdownItems();
+    const userToggleButton = this.buildUserToggleButton();
+    const userDropdownItems = this.buildUserDropdownItems();
 
+    const infoDropdownItems = this.buildInfoDropdownItems();
+
+    const branding = this.props.branding.data;
     return (
-      <PageHeaderTools>
-        <PageHeaderToolsGroup>
-          <PageHeaderToolsItem>
-            <Dropdown
-              isPlain
-              position="right"
-              onSelect={() => this.onSelect()}
-              isOpen={isOpen}
-              toggle={toggleButton}
-              dropdownItems={dropdownItems}
-            />
-          </PageHeaderToolsItem>
-        </PageHeaderToolsGroup>
-        {avatar}
-      </PageHeaderTools>
+      <>
+        <PageHeaderTools>
+          <PageHeaderToolsGroup>
+            <PageHeaderToolsItem>
+              <ApplicationLauncher
+                onToggle={() => this.onInfoDropdownToggle()}
+                isOpen={isInfoDropdownOpen}
+                items={infoDropdownItems}
+                position='right'
+                toggleIcon={<QuestionCircleIcon alt='' />}
+              />
+              <Dropdown
+                isPlain
+                position='right'
+                onSelect={() => this.onUsernameSelect()}
+                isOpen={isUsernameDropdownOpen}
+                toggle={userToggleButton}
+                dropdownItems={userDropdownItems}
+              />
+            </PageHeaderToolsItem>
+          </PageHeaderToolsGroup>
+          {avatar}
+        </PageHeaderTools>
+        <AboutModal
+          isOpen={isModalOpen}
+          closeAboutModal={() => this.closeAboutModal()}
+          username={this.props.user?.name}
+          logo={branding.logoFile}
+          productName={branding.name}
+          productVersion={branding.productVersion}
+        />
+      </>
     );
   }
-
 }
 
 const mapStateToProps = (state: AppState) => ({

--- a/src/Layout/Header/Tools/index.tsx
+++ b/src/Layout/Header/Tools/index.tsx
@@ -347,6 +347,7 @@ export class HeaderTools extends React.PureComponent<Props, State> {
                 onToggle={() => this.onInfoDropdownToggle()}
                 isOpen={isInfoDropdownOpen}
                 items={infoDropdownItems}
+                aria-label='info button'
                 position='right'
                 toggleIcon={<QuestionCircleIcon alt='' />}
               />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { createHashHistory } from 'history';
 
-import './overrides.css';
+import './overrides.styl';
 import '@patternfly/react-core/dist/styles/base.css';
 import 'monaco-editor-core/esm/vs/base/browser/ui/codiconLabel/codicon/codicon.css';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { createHashHistory } from 'history';
 
+import './overrides.css';
 import '@patternfly/react-core/dist/styles/base.css';
 import 'monaco-editor-core/esm/vs/base/browser/ui/codiconLabel/codicon/codicon.css';
 

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+/*
+ * This file is for patternfly css specific overrides
+ */
+
+.pf-c-app-launcher__menu-item-external-icon {
+  color: var(--pf-global--icon--Color--light) !important;
+  opacity: 1 !important;
+}

--- a/src/overrides.styl
+++ b/src/overrides.styl
@@ -14,7 +14,7 @@
  * This file is for patternfly css specific overrides
  */
 
-.pf-c-app-launcher__menu-item-external-icon {
-  color: var(--pf-global--icon--Color--light) !important;
-  opacity: 1 !important;
-}
+.pf-c-app-launcher__menu-item-external-icon
+  color var(--pf-global--icon--Color--light) !important
+  opacity 1 !important
+

--- a/src/services/bootstrap/PreloadData.ts
+++ b/src/services/bootstrap/PreloadData.ts
@@ -41,9 +41,9 @@ export class PreloadData {
   }
 
   async init(): Promise<void> {
-    await this.updateBranding();
     await this.updateUser();
     await this.updateKeycloakUserInfo();
+    await this.updateBranding();
 
     this.updateRestApiClient();
     await this.updateJsonRpcMasterApi();

--- a/src/store/Branding.ts
+++ b/src/store/Branding.ts
@@ -15,6 +15,8 @@ import { fetchBranding } from '../services/assets/branding';
 import { AppThunkAction, AppState } from '.';
 import { merge } from 'lodash';
 import { BRANDING_DEFAULT, BrandingData } from '../services/bootstrap/branding.constant';
+import { container } from '../inversify.config';
+import { CheWorkspaceClient } from '../services/cheWorkspaceClient';
 
 const ASSET_PREFIX = './assets/branding/';
 
@@ -42,6 +44,8 @@ export type ActionCreators = {
   requestBranding: () => any;
 };
 
+const cheWorkspaceClient = container.get(CheWorkspaceClient);
+
 export const actionCreators: ActionCreators = {
 
   requestBranding: (): AppThunkAction<KnownActions> =>
@@ -62,6 +66,11 @@ export const actionCreators: ActionCreators = {
       try {
         const receivedBranding = await fetchBranding(url);
         const branding = getBrandingData(receivedBranding);
+
+        const productVersion = await cheWorkspaceClient.restApiClient.getApiInfo();
+
+        // Use the products version if specified in product.json, otherwise use the default version given by che server
+        branding.productVersion = branding.productVersion ? branding.productVersion : productVersion['implementationVersion'];
 
         dispatch({
           type: 'RECEIVED_BRANDING',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3212,6 +3212,11 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+detect-browser@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-5.2.0.tgz#c9cd5afa96a6a19fda0bbe9e9be48a6b6e1e9c97"
+  integrity sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA==
+
 detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"


### PR DESCRIPTION
This PR implements the info button and the about modal. In the masthead screenshot FAQ isn't shown because it doesn't seem to be in the product.json and I can't seem to find an FAQ page on the Che docs. Che Version isn't in the product.json either (but when you add it manually everything shows up correctly). All the Kubernetes related things like version, channel, cluster ID, api server, etc need access to the kubernetes api directly and that currently isn't possible. When you try and call the kubernetes api directly and it's on a different host you'll end up running into a CORS issue. The only way its possible to do this is by using the che-server unsupported kubernetes api (AFAIK) but that only works when using openshift-oauth. Also, there doesn't seem to be any trademark data coming from the product.json AFAIK

related issue: https://github.com/eclipse/che/issues/18567
this was used as the reference: https://github.com/eclipse/che/issues/18567#issuecomment-742640132
other related issue: https://github.com/eclipse/che/issues/18635

pre-req PR's: https://github.com/eclipse/che-workspace-client/pull/48



Masthead
![2020-12-16-144355_669x393_scrot](https://user-images.githubusercontent.com/8839537/102398258-0d4d6480-3fad-11eb-9a0f-d722970d4865.png)

Modal
![2020-12-16-144404_1410x960_scrot](https://user-images.githubusercontent.com/8839537/102398259-0de5fb00-3fad-11eb-9bd3-704716bbb324.png)

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>