### PR TITLE
Add browser name to about modal

### DIFF
--- a/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
+++ b/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
@@ -72,4 +72,10 @@ describe('About modal', () => {
     expect(getByText(/Browser OS/i)).not.toBeNull();
     expect(getByText(/Linux/i)).not.toBeNull();
   });
+
+  it('should display browser name', () => {
+    const { getByText } = render(component);
+    expect(getByText(/Browser Name/i)).not.toBeNull();
+    expect(getByText(/chrome/i)).not.toBeNull();
+  });
 });

--- a/src/Layout/Header/Tools/about-modal.tsx
+++ b/src/Layout/Header/Tools/about-modal.tsx
@@ -66,6 +66,14 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = (
               </TextListItem>
             </>
           )}
+          {browserName && (
+            <>
+              <TextListItem component='dt'>Browser Name</TextListItem>
+              <TextListItem component='dd' className='co-select-to-copy'>
+                {browserName}
+              </TextListItem>
+            </>
+          )}
           {browserVersion && (
             <>
               <TextListItem component='dt'>Browser Version</TextListItem>
@@ -79,14 +87,6 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = (
               <TextListItem component='dt'>Browser OS</TextListItem>
               <TextListItem component='dd' className='co-select-to-copy'>
                 {browserOS}
-              </TextListItem>
-            </>
-          )}
-          {browserName && (
-            <>
-              <TextListItem component='dt'>Browser Name</TextListItem>
-              <TextListItem component='dd' className='co-select-to-copy'>
-                {browserName}
               </TextListItem>
             </>
           )}

--- a/src/Layout/Header/Tools/about-modal.tsx
+++ b/src/Layout/Header/Tools/about-modal.tsx
@@ -34,6 +34,7 @@ type AboutModalItemsProps = {
   productName: string | undefined;
   browserVersion: string | null | undefined;
   browserOS: string | null | undefined;
+  browserName: string | null | undefined;
 };
 
 const AboutModalItems: React.FC<AboutModalItemsProps> = (
@@ -44,6 +45,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = (
   const username = props.username;
   const browserVersion = props.browserVersion;
   const browserOS = props.browserOS;
+  const browserName = props.browserName;
   return (
     <>
       <TextContent>
@@ -80,6 +82,14 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = (
               </TextListItem>
             </>
           )}
+          {browserName && (
+            <>
+              <TextListItem component='dt'>Browser Name</TextListItem>
+              <TextListItem component='dd' className='co-select-to-copy'>
+                {browserName}
+              </TextListItem>
+            </>
+          )}
         </TextList>
       </TextContent>
     </>
@@ -97,6 +107,7 @@ export class AboutModal extends React.PureComponent<AboutModalProps> {
     const browser = detect();
     const browserVersion = browser?.version;
     const browserOS = browser?.os;
+    const browserName = browser?.name;
 
     return (
       <PatternflyAboutModal
@@ -111,6 +122,7 @@ export class AboutModal extends React.PureComponent<AboutModalProps> {
           username={userName}
           browserOS={browserOS}
           browserVersion={browserVersion}
+          browserName={browserName}
           productName={productName}
         />
       </PatternflyAboutModal>


### PR DESCRIPTION
This PR adds browser name into the about modal

related part of issue: https://github.com/eclipse/che/issues/18567#issuecomment-750873611

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>