### PR TITLE
Add ability to open a workspace in debug mode from the progress tab

### DIFF
--- a/src/components/Workspace/DeleteAction/__tests__/DeleteAction.spec.tsx
+++ b/src/components/Workspace/DeleteAction/__tests__/DeleteAction.spec.tsx
@@ -180,6 +180,7 @@ function createComponent(
         clearWorkspaceQualifiedName={jest.fn()}
         setWorkspaceId={jest.fn()}
         clearWorkspaceId={jest.fn()}
+        deleteWorkspaceLogs={jest.fn()}
       >Delete Workspace</WorkspaceDeleteAction>
     </Provider>
   );

--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -10,18 +10,18 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { AlertVariant } from '@patternfly/react-core';
+import { AlertActionLink, AlertVariant } from '@patternfly/react-core';
 import { History } from 'history';
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 import { container } from '../inversify.config';
-import IdeLoaderPage from '../pages/IdeLoader';
+import IdeLoaderPage, { AlertOptions } from '../pages/IdeLoader';
 import { Debounce } from '../services/helpers/debounce';
 import { IdeLoaderTabs, WorkspaceStatus } from '../services/helpers/types';
 import { AppState } from '../store';
 import * as WorkspaceStore from '../store/Workspaces';
-import { selectAllWorkspaces, selectWorkspaceById } from '../store/Workspaces/selectors';
+import { selectAllWorkspaces, selectLogs, selectWorkspaceById } from '../store/Workspaces/selectors';
 
 type Props =
   MappedProps
@@ -35,9 +35,9 @@ export enum LoadIdeSteps {
 }
 
 type State = {
-  namespace: string,
-  workspaceName: string,
-  workspaceId?: string,
+  namespace: string;
+  workspaceName: string;
+  workspaceId?: string;
   currentStep: LoadIdeSteps;
   preselectedTabKey?: IdeLoaderTabs;
   ideUrl?: string;
@@ -47,7 +47,7 @@ type State = {
 class IdeLoader extends React.PureComponent<Props, State> {
   private debounce: Debounce;
   private readonly loadFactoryPageCallbacks: {
-    showAlert?: (variant: AlertVariant, title: string) => void
+    showAlert?: (alertOptions: AlertOptions) => void
   };
 
   constructor(props: Props) {
@@ -63,10 +63,13 @@ class IdeLoader extends React.PureComponent<Props, State> {
       history.replace({ pathname });
     }
 
+    const workspace = this.props.allWorkspaces.find(workspace =>
+      workspace.namespace === params.namespace && workspace.devfile.metadata.name === this.workspaceName);
     this.state = {
       currentStep: LoadIdeSteps.INITIALIZING,
       namespace,
       workspaceName,
+      hasError: workspace.status === WorkspaceStatus[WorkspaceStatus.ERROR],
       preselectedTabKey: this.preselectedTabKey,
     };
 
@@ -95,14 +98,21 @@ class IdeLoader extends React.PureComponent<Props, State> {
     return IdeLoaderTabs.Progress;
   }
 
-  public showAlert(message: string, alertVariant: AlertVariant = AlertVariant.danger): void {
-    if (alertVariant === AlertVariant.danger) {
+  public showAlert(alertOptions: string | AlertOptions): void {
+    if (typeof alertOptions == 'string') {
+      const currentAlertOptions = alertOptions;
+      alertOptions = {
+        title: currentAlertOptions,
+        alertVariant: AlertVariant.danger
+      } as AlertOptions;
+    }
+    if (alertOptions.alertVariant === AlertVariant.danger) {
       this.setState({ hasError: true });
     }
     if (this.loadFactoryPageCallbacks.showAlert) {
-      this.loadFactoryPageCallbacks.showAlert(alertVariant, message);
+      this.loadFactoryPageCallbacks.showAlert(alertOptions);
     } else {
-      console.error(message);
+      console.error(alertOptions.title);
     }
   }
 
@@ -121,28 +131,84 @@ class IdeLoader extends React.PureComponent<Props, State> {
     if (workspace && workspace.runtime && workspace.status === WorkspaceStatus[WorkspaceStatus.RUNNING]) {
       this.updateIdeUrl(workspace.runtime);
       return;
+    } else if (workspace && workspace.status == WorkspaceStatus[WorkspaceStatus.ERROR]) {
+      this.showErrorAlert(workspace);
     }
     this.debounce.setDelay(1000);
   }
 
-  public async componentDidUpdate(): Promise<void> {
+  private showErrorAlert(workspace: che.Workspace) {
+    const wsLogs = this.props.workspacesLogs.get(workspace.id) || [];
+    const alertActionLinks = this.errorActionLinks(workspace);
+    this.showAlert({
+      alertActionLinks: alertActionLinks,
+      title: `Workspace ${this.state.workspaceName} failed to start`,
+      body: this.findErrorLogs(wsLogs).join('\n'),
+      alertVariant: AlertVariant.danger
+    });
+  }
+
+  public async componentDidUpdate(prevProps, prevState): Promise<void> {
     const { allWorkspaces, match: { params } } = this.props;
     const { hasError } = this.state;
     const workspace = allWorkspaces.find(workspace =>
       workspace.namespace === params.namespace && workspace.devfile.metadata.name === this.workspaceName);
-    if (workspace && !hasError && workspace.status === WorkspaceStatus[WorkspaceStatus.ERROR]) {
-      try {
-        await this.props.requestWorkspace(workspace.id);
-        if (workspace.status === WorkspaceStatus[WorkspaceStatus.ERROR]) {
-          this.setState({ hasError: true });
-          this.showAlert(`Workspace ${this.state.workspaceName} failed to start. Check logs.`);
-        }
-      } catch (e) {
-        this.showAlert(`Getting workspace detail data failed. ${e}`);
-        return;
-      }
+    if (workspace && ((prevState.workspaceName === this.workspaceName) && !hasError) && workspace.status === WorkspaceStatus[WorkspaceStatus.ERROR]) {
+      // When the current workspace didn't have an error but now does then show it
+      this.showErrorAlert(workspace);
+    } else if (workspace && (prevState.workspaceName !== this.workspaceName) && workspace.status === WorkspaceStatus[WorkspaceStatus.ERROR]) {
+      // When the clicked workspace changes and the new one errors then show the new error message
+      this.setState({ hasError: true, workspaceName: this.workspaceName, currentStep: LoadIdeSteps.START_WORKSPACE, workspaceId: workspace.id });
+      this.showErrorAlert(workspace);
+    } else if (prevState.workspaceName !== this.workspaceName) {
+      // There is no error in the newly opened workspace so just reset the status back to the initial state
+      this.setState({ hasError: false, workspaceName: this.workspaceName, currentStep: LoadIdeSteps.INITIALIZING, workspaceId: workspace.id });
     }
     this.debounce.setDelay(1000);
+  }
+
+  private findErrorLogs(wsLogs: string[]): string[] {
+    const errorLogs: string[] = [];
+    wsLogs.forEach(e => {
+      if (e.startsWith('Error: Failed to run the workspace')) {
+        // Remove the default error message and the quotations that surround the error
+        const strippedError = e.replace('Error: Failed to run the workspace: ', '').slice(1, -1);
+        errorLogs.push(strippedError);
+      }
+    });
+    return errorLogs;
+  }
+
+  private errorActionLinks(workspace: che.Workspace): React.ReactFragment {
+    return (
+      <React.Fragment>
+        <AlertActionLink onClick={async () => {
+          try {
+            await this.props.startWorkspace(workspace.id, { 'debug-workspace-start': true });
+            await this.props.deleteWorkspaceLogs(workspace.id);
+            this.setState({
+              currentStep: LoadIdeSteps.INITIALIZING,
+              hasError: false
+            });
+
+            // Set the workspaces status to starting manually so that when initWorkspace
+            // is triggered on the debounce the workspace won't be attempted to start twice
+            workspace.status = 'STARTING';
+          } catch (e) {
+            this.showAlert(`Workspace ${this.state.workspaceName} failed to start. ${e}`);
+          }
+        }}>Open in Debug mode</AlertActionLink>
+        <AlertActionLink onClick={() => {
+          // Since patternfly appends numbers to an id we can't just get the tab by id so look for the tab item with Logs
+          const elements: any = Array.from(document.getElementsByClassName('pf-c-tabs__item'));
+          for (const ele of elements) {
+            if (ele.innerText === 'Logs') {
+              ele.firstChild.click();
+            }
+          }
+        }}>Open Logs</AlertActionLink>
+      </React.Fragment>
+    );
   }
 
   private updateIdeUrl(runtime: api.che.workspace.Runtime): void {
@@ -184,10 +250,12 @@ class IdeLoader extends React.PureComponent<Props, State> {
     const { allWorkspaces, match: { params } } = this.props;
     const { namespace, workspaceName } = this.state;
 
+    const workspace = allWorkspaces.find(workspace =>
+      workspace.namespace === params.namespace && workspace.devfile.metadata.name === this.workspaceName);
     if (namespace !== params.namespace || workspaceName !== this.workspaceName) {
       this.setState({
         currentStep: LoadIdeSteps.INITIALIZING,
-        hasError: false,
+        hasError: workspace?.status === WorkspaceStatus[WorkspaceStatus.ERROR] ? true : false,
         ideUrl: '',
         namespace: params.namespace,
         workspaceName: this.workspaceName,
@@ -196,8 +264,6 @@ class IdeLoader extends React.PureComponent<Props, State> {
     } else if (this.state.currentStep === LoadIdeSteps.OPEN_IDE) {
       return;
     }
-    const workspace = allWorkspaces.find(workspace =>
-      workspace.namespace === params.namespace && workspace.devfile.metadata.name === this.workspaceName);
     if (workspace) {
       this.setState({ workspaceId: workspace.id });
       if ((workspace.runtime || this.state.currentStep === LoadIdeSteps.START_WORKSPACE) &&
@@ -210,8 +276,7 @@ class IdeLoader extends React.PureComponent<Props, State> {
     }
     if (this.state.currentStep === LoadIdeSteps.INITIALIZING) {
       this.setState({ currentStep: LoadIdeSteps.START_WORKSPACE });
-      if (workspace.status === WorkspaceStatus[WorkspaceStatus.STOPPED] ||
-        workspace.status === WorkspaceStatus[WorkspaceStatus.ERROR]) {
+      if (workspace.status === WorkspaceStatus[WorkspaceStatus.STOPPED] && (this.state.hasError !== true)) {
         try {
           await this.props.startWorkspace(`${workspace.id}`);
         } catch (e) {
@@ -243,6 +308,7 @@ class IdeLoader extends React.PureComponent<Props, State> {
 const mapStateToProps = (state: AppState) => ({
   workspace: selectWorkspaceById(state),
   allWorkspaces: selectAllWorkspaces(state),
+  workspacesLogs: selectLogs(state)
 });
 
 const connector = connect(

--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -197,7 +197,7 @@ class IdeLoader extends React.PureComponent<Props, State> {
           } catch (e) {
             this.showAlert(`Workspace ${this.state.workspaceName} failed to start. ${e}`);
           }
-        }}>Open in Debug mode</AlertActionLink>
+        }}>Open in Verbose mode</AlertActionLink>
         <AlertActionLink onClick={() => {
           // Since patternfly appends numbers to an id we can't just get the tab by id so look for the tab item with Logs
           const elements: any = Array.from(document.getElementsByClassName('pf-c-tabs__item'));

--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -148,7 +148,7 @@ class IdeLoader extends React.PureComponent<Props, State> {
     });
   }
 
-  public async componentDidUpdate(prevProps, prevState): Promise<void> {
+  public async componentDidUpdate(prevProps: Props, prevState: Props): Promise<void> {
     const { allWorkspaces, match: { params } } = this.props;
     const { hasError } = this.state;
     const workspace = allWorkspaces.find(workspace =>

--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -69,7 +69,7 @@ class IdeLoader extends React.PureComponent<Props, State> {
       currentStep: LoadIdeSteps.INITIALIZING,
       namespace,
       workspaceName,
-      hasError: workspace.status === WorkspaceStatus[WorkspaceStatus.ERROR],
+      hasError: workspace?.status === WorkspaceStatus[WorkspaceStatus.ERROR],
       preselectedTabKey: this.preselectedTabKey,
     };
 

--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -183,32 +183,42 @@ class IdeLoader extends React.PureComponent<Props, State> {
     return (
       <React.Fragment>
         <AlertActionLink onClick={async () => {
-          try {
-            await this.props.startWorkspace(workspace.id, { 'debug-workspace-start': true });
-            await this.props.deleteWorkspaceLogs(workspace.id);
-            this.setState({
-              currentStep: LoadIdeSteps.INITIALIZING,
-              hasError: false
-            });
-
-            // Set the workspaces status to starting manually so that when initWorkspace
-            // is triggered on the debounce the workspace won't be attempted to start twice
-            workspace.status = 'STARTING';
-          } catch (e) {
-            this.showAlert(`Workspace ${this.state.workspaceName} failed to start. ${e}`);
-          }
+          this.verboseModeHandler(workspace);
         }}>Open in Verbose mode</AlertActionLink>
         <AlertActionLink onClick={() => {
           // Since patternfly appends numbers to an id we can't just get the tab by id so look for the tab item with Logs
-          const elements: any = Array.from(document.getElementsByClassName('pf-c-tabs__item'));
-          for (const ele of elements) {
-            if (ele.innerText === 'Logs') {
-              ele.firstChild.click();
-            }
-          }
+          this.logsHandler();
         }}>Open Logs</AlertActionLink>
       </React.Fragment>
     );
+  }
+
+  private async verboseModeHandler(workspace: che.Workspace) {
+    try {
+      await this.props.startWorkspace(workspace.id, { 'debug-workspace-start': true });
+      await this.props.deleteWorkspaceLogs(workspace.id);
+      this.setState({
+        currentStep: LoadIdeSteps.INITIALIZING,
+        hasError: false
+      });
+
+      // Set the workspaces status to starting manually so that when initWorkspace
+      // is triggered on the debounce the workspace won't be attempted to start twice
+      workspace.status = 'STARTING';
+
+      this.logsHandler();
+    } catch (e) {
+      this.showAlert(`Workspace ${this.state.workspaceName} failed to start. ${e}`);
+    }
+  }
+
+  private logsHandler() {
+    const elements: any = Array.from(document.getElementsByClassName('pf-c-tabs__item'));
+    for (const ele of elements) {
+      if (ele.innerText === 'Logs') {
+        ele.firstChild.click();
+      }
+    }
   }
 
   private updateIdeUrl(runtime: api.che.workspace.Runtime): void {

--- a/src/containers/__tests__/IdeLoader.spec.tsx
+++ b/src/containers/__tests__/IdeLoader.spec.tsx
@@ -10,7 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { AlertVariant } from '@patternfly/react-core';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { RenderResult, render, screen } from '@testing-library/react';
@@ -20,12 +19,14 @@ import { createFakeStore } from '../../store/__mocks__/store';
 import { createFakeWorkspace } from '../../store/__mocks__/workspace';
 import { WorkspaceStatus } from '../../services/helpers/types';
 import IdeLoader, { LoadIdeSteps } from '../IdeLoader';
+import { AlertOptions } from '../../pages/IdeLoader';
+import { AlertActionLink } from '@patternfly/react-core';
 
 jest.mock('../../store/Workspaces/index', () => {
   return { actionCreators: {} };
 });
 
-const showAlert = jest.fn();
+let showAlert = jest.fn();
 
 jest.mock('../../pages/IdeLoader', () => {
   return function DummyWizard(props: {
@@ -35,7 +36,7 @@ jest.mock('../../pages/IdeLoader', () => {
     workspaceId: string;
     ideUrl?: string;
     callbacks?: {
-      showAlert?: (variant: AlertVariant, title: string) => void
+      showAlert?: (alertOptions: AlertOptions) => void
     }
   }): React.ReactElement {
     if (props.callbacks) {
@@ -87,7 +88,13 @@ describe('IDE Loader container', () => {
       'admin2',
       WorkspaceStatus[WorkspaceStatus.RUNNING],
       runtime
-    )
+    ),
+    createFakeWorkspace(
+      'id-wksp-3',
+      'name-wksp-3',
+      'admin3',
+      WorkspaceStatus[WorkspaceStatus.ERROR]
+    ),
   ]);
 
   const renderComponent = (
@@ -108,7 +115,38 @@ describe('IDE Loader container', () => {
     );
   };
 
+  beforeEach(() => {
+    showAlert = jest.fn();
+  });
+
   it('should show an error if something wrong', () => {
+    const namespace = 'admin3';
+    const workspaceName = 'name-wksp-4';
+
+    const requestWorkspace = jest.fn();
+    const startWorkspace = jest.fn();
+
+    renderComponent(
+      namespace,
+      workspaceName,
+      startWorkspace,
+      requestWorkspace);
+
+    expect(startWorkspace).not.toBeCalled();
+    expect(requestWorkspace).not.toBeCalled();
+    expect(showAlert).toBeCalledWith(expect.objectContaining({
+      alertVariant: 'danger',
+      title: 'Failed to find the target workspace.'
+    }));
+
+    const elementHasError = screen.getByTestId('ide-loader-has-error');
+    expect(elementHasError.innerHTML).toEqual('true');
+
+    const elementCurrentStep = screen.getByTestId('ide-loader-current-step');
+    expect(LoadIdeSteps[elementCurrentStep.innerHTML]).toEqual(LoadIdeSteps[LoadIdeSteps.INITIALIZING]);
+  });
+
+  it('error links are passed to alert when workspace start error is found', () => {
     const namespace = 'admin3';
     const workspaceName = 'name-wksp-3';
 
@@ -123,13 +161,20 @@ describe('IDE Loader container', () => {
 
     expect(startWorkspace).not.toBeCalled();
     expect(requestWorkspace).not.toBeCalled();
-    expect(showAlert).toBeCalledWith('danger', 'Failed to find the target workspace.');
+
+    expect(showAlert).toBeCalledTimes(1);
+
+    const errorAlerts = <React.Fragment><AlertActionLink onClick={() => jest.fn()}>Open in Debug mode</AlertActionLink><AlertActionLink onClick={() => jest.fn()}>Open Logs</AlertActionLink></React.Fragment>;
+    const firstCalledArgs = showAlert.mock.calls[0][0];
+    expect(firstCalledArgs.title).toEqual('Workspace name-wksp-3 failed to start');
+    expect(firstCalledArgs.alertVariant).toEqual('danger');
+    expect(JSON.stringify(firstCalledArgs.alertActionLinks)).toEqual(JSON.stringify(errorAlerts));
 
     const elementHasError = screen.getByTestId('ide-loader-has-error');
     expect(elementHasError.innerHTML).toEqual('true');
 
     const elementCurrentStep = screen.getByTestId('ide-loader-current-step');
-    expect(LoadIdeSteps[elementCurrentStep.innerHTML]).toEqual(LoadIdeSteps[LoadIdeSteps.INITIALIZING]);
+    expect(LoadIdeSteps[elementCurrentStep.innerHTML]).toEqual(LoadIdeSteps[LoadIdeSteps.START_WORKSPACE]);
   });
 
   it('should have correct WORKSPACE START and waiting for the workspace runtime', () => {

--- a/src/containers/__tests__/IdeLoader.spec.tsx
+++ b/src/containers/__tests__/IdeLoader.spec.tsx
@@ -164,7 +164,7 @@ describe('IDE Loader container', () => {
 
     expect(showAlert).toBeCalledTimes(1);
 
-    const errorAlerts = <React.Fragment><AlertActionLink onClick={() => jest.fn()}>Open in Debug mode</AlertActionLink><AlertActionLink onClick={() => jest.fn()}>Open Logs</AlertActionLink></React.Fragment>;
+    const errorAlerts = <React.Fragment><AlertActionLink onClick={() => jest.fn()}>Open in Verbose mode</AlertActionLink><AlertActionLink onClick={() => jest.fn()}>Open Logs</AlertActionLink></React.Fragment>;
     const firstCalledArgs = showAlert.mock.calls[0][0];
     expect(firstCalledArgs.title).toEqual('Workspace name-wksp-3 failed to start');
     expect(firstCalledArgs.alertVariant).toEqual('danger');

--- a/src/store/Workspaces/index.ts
+++ b/src/store/Workspaces/index.ts
@@ -142,6 +142,7 @@ export type ActionCreators = {
   clearWorkspaceQualifiedName: () => AppThunk<ClearWorkspaceQualifiedName>;
   setWorkspaceId: (workspaceId: string) => AppThunk<SetWorkspaceId>;
   clearWorkspaceId: () => AppThunk<ClearWorkspaceId>;
+  deleteWorkspaceLogs: (workspaceId: string) => AppThunk<KnownAction>;
 };
 
 type WorkspaceStatusMessageHandler = (message: api.che.workspace.event.WorkspaceStatusEvent) => void;
@@ -191,7 +192,7 @@ function unSubscribeToStatusChange(workspaceId: string): void {
 
 function subscribeToEnvironmentOutput(workspaceId: string, dispatch: ThunkDispatch<State, undefined, UpdateWorkspacesLogsAction | DeleteWorkspaceLogsAction>): void {
   const callback: EnvironmentOutputMessageHandler = message => {
-    if (message.text) {
+    if (message.runtimeId?.workspaceId === workspaceId && message.text) {
       const workspacesLogs = new Map<string, string[]>();
       workspacesLogs.set(workspaceId, [`${message.text}`]);
       dispatch({
@@ -356,6 +357,14 @@ export const actionCreators: ActionCreators = {
 
   clearWorkspaceId: (): AppThunk<ClearWorkspaceId> => dispatch => {
     dispatch({ type: 'CLEAR_WORKSPACE_ID' });
+  },
+
+  deleteWorkspaceLogs: (workspaceId: string): AppThunk<KnownAction> => async (dispatch): Promise<void> => {
+    dispatch({
+      type: 'SET_WORKSPACE_ID',
+      workspaceId,
+    });
+    dispatch({ type: 'DELETE_WORKSPACE_LOGS', workspaceId });
   },
 
 };


### PR DESCRIPTION
### What does this PR do?

This PR makes it so that you can restart your workspace in debug mode from the progress tab if it errored when starting.

When `Open in Debug mode` is clicked the previous workspace logs for the current workspace will be cleared and then the workspace will be started in debug mode.

When `Open logs` is clicked the logs tab is opened.

The easiest way to test this is by starting a workspace then stopping it, creating a runtime error. From there, click into the workspace on the left panel and see that the workspace doesn't automatically restart and that you can use the open logs and open in debug mode buttons.

Tests are in progress

Picture:
![2020-12-31-082242_1221x436_scrot](https://user-images.githubusercontent.com/8839537/103411931-cf217a80-4b40-11eb-9462-a1b94b25e93d.png)

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### Which issue does this PR related to?

https://github.com/eclipse/che/issues/18640