### PR TITLE
Align README with Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
-# About Eclipse Che Dashboard
+## About Eclipse Che
 
-This is the first step to implement a new Eclipse Che Dashboard.
+Eclipse Che is a next generation Eclipse IDE. This repository is licensed under the Eclipse Public License 2.0. Visit [Eclipse Che's Web site](https://eclipse.org/che/) for feature information or the main [Che assembly repository](https://github.com/eclipse/che) for a description of all participating repositories.
+
+# Eclipse Che Dashboard
 
 ## Requirements
 
 - Node.js `v10.x.x` and later.
+- yarn `v1.20.0` or higher.
+
+**Note**:
+Below you can find installation instructions
+- [Node.js](https://docs.npmjs.com/getting-started/installing-node)
+- [yarn](https://yarnpkg.com/lang/en/docs/install/)
 
 ## Quick start
 
@@ -49,6 +57,24 @@ and then run the license-tool:
 
 ```sh
 yarn licenseCheck:run
+```
+
+## Branding
+
+Default branding data for the User Dashboard is located in [branding.constant.ts](src/services/bootstrap/branding.constant.ts)#BRANDING_DEFAULT. It can be overridden without re-building the project in [product.json](/assets/branding/product.json) file which should contain only values that should overwrite default ones.
+
+### Configurability
+
+Field `"configuration.cheCliTool"` should contain the name of a CLI tool that is recommended to be used to work with Che Server from the terminal. It's the `"chectl"` by default.
+
+Example:
+
+```json
+{
+  "configuration": {
+    "cheCliTool": "chectl"
+  }
+}
 ```
 
 ## License


### PR DESCRIPTION
### What does this PR do?

This PR alignes README with Dashboard.

Note 

```
The `"configuration.prefetch"` section allows to define resources that UD should pre-fetch. This section consists of following optional fields:

- `"resources"` is an array of urls to resources to pre-fetch;
- `"cheCDN"` which is Che specific and points to API endpoint that gives resources to pre-fetch,
  e.g. response from `"/api/cdn-support/paths"` on `che.openshift.io` has following structure and each of these entries will be pre-fetched:

  ```json
  [
    {
      "chunk": "che.12debab20b181e07ac86.js",
      "cdn": "https://static.developers.redhat.com/che/theia_artifacts/che.12debab20b181e07ac86.js"
    },
    ...
    {
      "external": "vs/editor/editor.main.css",
      "cdn": "https://cdn.jsdelivr.net/npm/@typefox/monaco-editor-core@0.18.0-next.1/min/vs/editor/editor.main.css"
    },
    ...
  ]
  ```

is not migrated from Dashboard since it's not implemented yet. It should be added after https://github.com/eclipse/che/issues/18728 is done.