### PR TITLE
Fix page loading when websockets are not available

### DIFF
--- a/src/services/bootstrap/PreloadData.ts
+++ b/src/services/bootstrap/PreloadData.ts
@@ -46,7 +46,7 @@ export class PreloadData {
     await this.updateBranding();
 
     this.updateRestApiClient();
-    await this.updateJsonRpcMasterApi();
+    this.updateJsonRpcMasterApi();
 
     this.updateWorkspaces();
     this.updateInfrastructureNamespaces();

--- a/src/services/storageTypes.ts
+++ b/src/services/storageTypes.ts
@@ -10,6 +10,8 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
+const DEFAULT_AVAILABLE_TYPES = '';
+
 export enum StorageTypeTitle {
   async = 'Asynchronous',
   ephemeral = 'Ephemeral',
@@ -37,7 +39,7 @@ export function fromTitle(title: string): che.WorkspaceStorageType {
 }
 
 export function getAvailable(settings: che.WorkspaceSettings): che.WorkspaceStorageType[] {
-  const availableTypes = settings['che.workspace.storage.available_types'];
+  const availableTypes = settings['che.workspace.storage.available_types'] || DEFAULT_AVAILABLE_TYPES;
   return availableTypes.split(',') as che.WorkspaceStorageType[];
 }
 
@@ -62,7 +64,7 @@ export function typeToAttributes(type: che.WorkspaceStorageType): che.WorkspaceC
 }
 
 export function attributesToType(attrs: che.WorkspaceConfigAttributes | undefined): che.WorkspaceStorageType {
-  if ( attrs?.persistVolumes === 'false') {
+  if (attrs?.persistVolumes === 'false') {
     if (attrs.asyncPersist === 'true') {
       return 'async';
     }


### PR DESCRIPTION
### What does this PR do?
This PR makes it so that if websockets aren't available the page will still load correctly. Previously, if you had websockets disabled and try to open the dashboard the view will instantly go white and the console will contain an error with `TypeError: availableTypes is undefined`. This way makes it so that everything will work correctly in PreloadData

### Which issue does this PR related to?
Pre-req for https://github.com/eclipse/che/issues/18490

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>