### PR TITLE
Modify the incoming request auth header to use the new bearer token

### DIFF
--- a/src/services/cheWorkspaceClient/index.ts
+++ b/src/services/cheWorkspaceClient/index.ts
@@ -64,6 +64,7 @@ export class CheWorkspaceClient {
               if (refreshed && keycloak.token) {
                 const header = 'Authorization';
                 this.axios.defaults.headers.common[header] = `Bearer ${keycloak.token}`;
+                request.headers.common[header] = `Bearer ${keycloak.token}`;
               }
               resolve(keycloak);
             }).error((error: any) => {


### PR DESCRIPTION
### What does this PR do?
Currently, when a request is made and the token is refreshed through the interceptors the incoming request token isn't modified, leading to issues like https://github.com/eclipse/che/issues/18311#issuecomment-742478977. This PR makes sure that the incoming request token is updated when the keycloak token is updated

### Which issue is this PR related to?
https://github.com/eclipse/che/issues/18311

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>