### PR TITLE
Add banner that triggers when websockets arent available

### DIFF
--- a/src/Layout/index.tsx
+++ b/src/Layout/index.tsx
@@ -24,6 +24,7 @@ import { KeycloakAuthService } from '../services/keycloak/auth';
 import { IssuesReporterService } from '../services/bootstrap/issuesReporter';
 import { ErrorReporter } from './ErrorReporter';
 import { IssueComponent } from './ErrorReporter/Issue';
+import WebSocketBannerAlert from '../components/WebSocketBannerAlert';
 
 const issuesReporterService = container.get(IssuesReporterService);
 
@@ -149,6 +150,7 @@ export class Layout extends React.PureComponent<Props, State> {
         }
         isManagedSidebar={IS_MANAGED_SIDEBAR}
       >
+        <WebSocketBannerAlert />
         {this.props.children}
       </Page>
     );

--- a/src/components/WebSocketBannerAlert/__tests__/WebSocketBannerAlert.spec.tsx
+++ b/src/components/WebSocketBannerAlert/__tests__/WebSocketBannerAlert.spec.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { container } from '../../../inversify.config';
+import WebSocketBannerAlert from '../';
+import { CheWorkspaceClient } from '../../../services/cheWorkspaceClient';
+import { Provider } from 'react-redux';
+import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
+import { BrandingData } from '../../../services/bootstrap/branding.constant';
+import { render, RenderResult } from '@testing-library/react';
+
+const failingWebSocketName = 'Failing websocket';
+
+class mockCheWorkspaceClient extends CheWorkspaceClient {
+  get failingWebSockets() { return [failingWebSocketName]; }
+}
+
+const store = new FakeStoreBuilder().withBranding({
+  docs: {
+    webSocketTroubleshooting: 'http://sample_documentation'
+  }
+} as BrandingData).build();
+
+describe('WebSocketBannerAlert component', () => {
+  it('should show error message when error found before mounting', () => {
+    container.rebind(CheWorkspaceClient).to(mockCheWorkspaceClient).inSingletonScope();
+    const component = renderComponent(<WebSocketBannerAlert />);
+    container.rebind(CheWorkspaceClient).to(CheWorkspaceClient).inSingletonScope();
+    expect(component.getAllByText(failingWebSocketName, {
+      exact: false
+    }).length).toEqual(1);
+  });
+
+  it('should show error message when error found after mounting', () => {
+    const comp = (
+      <Provider store={store}>
+        <WebSocketBannerAlert />
+      </Provider>
+    );
+    const component = renderComponent(comp);
+    expect(component.queryAllByText(failingWebSocketName, {
+      exact: false
+    })).toEqual([]);
+    container.rebind(CheWorkspaceClient).to(mockCheWorkspaceClient).inSingletonScope();
+    component.rerender(comp);
+    container.rebind(CheWorkspaceClient).to(CheWorkspaceClient).inSingletonScope();
+    expect(component.getAllByText(failingWebSocketName, {
+      exact: false
+    }).length).toEqual(1);
+  });
+
+  it('should not show error message if none is present', () => {
+    const component = renderComponent(<WebSocketBannerAlert />);
+    expect(component.queryAllByText(failingWebSocketName, {
+      exact: false
+    })).toEqual([]);
+  });
+
+});
+
+function renderComponent(
+  component: React.ReactElement
+): RenderResult {
+  return render(
+    <Provider store={store}>
+      {component}
+    </Provider>
+  );
+}

--- a/src/components/WebSocketBannerAlert/index.tsx
+++ b/src/components/WebSocketBannerAlert/index.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { Banner } from '@patternfly/react-core';
+import React from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+import { container } from '../../inversify.config';
+import { CheWorkspaceClient } from '../../services/cheWorkspaceClient';
+import { AppState } from '../../store';
+
+type Props = MappedProps & {};
+
+type State = {
+  erroringWebSockets: string[];
+};
+
+class WebSocketBannerAlert extends React.PureComponent<Props, State> {
+  private readonly cheWorkspaceClient: CheWorkspaceClient;
+
+  constructor(props: Props) {
+    super(props);
+    this.cheWorkspaceClient = container.get(CheWorkspaceClient);
+    this.state = {
+      erroringWebSockets: this.cheWorkspaceClient.failingWebSockets,
+    };
+  }
+
+  public componentWillUnmount() {
+    this.cheWorkspaceClient.removeWebSocketFailedListener();
+  }
+
+  public componentDidMount() {
+    this.cheWorkspaceClient.onWebSocketFailed(() => {
+      this.setState({
+        erroringWebSockets: this.cheWorkspaceClient.failingWebSockets,
+      });
+    });
+  }
+
+  render() {
+    if (this.state.erroringWebSockets.length === 0) {
+      return null;
+    }
+
+    const webSocketTroubleshootingDocs = this.props.brandingStore.data.docs
+      .webSocketTroubleshooting;
+    return (
+      // WebSocket connections are failing. Refer to Network Troubleshooting in the user guide.
+      <Banner className="pf-u-text-align-center" variant="warning">
+        WebSocket connections are failing. Refer to &quot;
+        <a href={webSocketTroubleshootingDocs} rel="noreferrer" target="_blank">
+          Network Troubleshooting
+        </a>&quot;
+        in the user guide.
+      </Banner>
+    );
+  }
+}
+
+const mapStateToProps = (state: AppState) => ({
+  brandingStore: state.branding,
+});
+
+const connector = connect(mapStateToProps);
+
+type MappedProps = ConnectedProps<typeof connector>;
+export default connector(WebSocketBannerAlert);


### PR DESCRIPTION
### What does this PR do?
This PR adds a new component called WebSocketBannerAlert that is used for showing the banner alert when a WebSocket is failing to connect

Pre-req PRs:
https://github.com/che-incubator/che-dashboard-next/pull/109
https://github.com/che-incubator/che-dashboard-next/pull/107
https://github.com/eclipse/che-workspace-client/pull/50

### Which issue is this PR related to?
https://github.com/eclipse/che/issues/18706

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>